### PR TITLE
docs: add model download instructions to README (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,30 @@ The constraints file pins the recommended versions. To use other compatible
 versions, omit `-c constraints/recommended.txt`; the compatibility ranges are
 declared in `pyproject.toml`.
 
+### Download Checkpoints
+
+The `hf` CLI is installed automatically as part of `huggingface-hub` above.
+Verify it is available:
+
+```bash
+hf --version
+```
+
+Then download a pretrained checkpoint:
+
+```bash
+hf download rednote-hilab/dots.tts-soar --local-dir pretrained_models/dots.tts-soar
+```
+
+| Checkpoint | Hugging Face ID | Description |
+|---|---|---|
+| **dots.tts-soar** | `rednote-hilab/dots.tts-soar` | SCA self-corrective aligned — best overall quality |
+| **dots.tts-base** | `rednote-hilab/dots.tts-base` | Pretrained base model (2B) |
+| **dots.tts-mf** | `rednote-hilab/dots.tts-mf` | MeanFlow distilled, NFE=4 — fastest inference |
+
+All checkpoints are 2B parameters and released under Apache-2.0. Choose **soar** for best
+quality, or **mf** for faster sampling with fewer flow steps.
+
 ### CLI
 
 The package installs a `dots.tts` entry point:


### PR DESCRIPTION
Add a "Download Checkpoints" subsection between Installation and CLI to guide users on downloading pretrained checkpoints via hf CLI. Includes a table of available checkpoints (soar, base, mf) with descriptions.

Closes #<issue-number>