### PR TITLE
Add two-step sCM inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,17 @@ The `constraints/recommended.txt` file pins the reproducible versions;
 
 ### Checkpoints
 
-Three pretrained checkpoints are released on Hugging Face. All three share the same backbone — choose by the quality / inference-cost tradeoff:
+Five pretrained checkpoints are released on Hugging Face. All five share the same backbone — choose by the quality / inference-cost tradeoff:
 
-| Model | Description | Recommended `--num-steps` |
+| Model | Description | Inference settings |
 |---|---|:---:|
 | [`rednote-hilab/dots.tts-base`](https://huggingface.co/rednote-hilab/dots.tts-base) | Pretrained checkpoint. | `10`–`32` (default `10`) |
 | [`rednote-hilab/dots.tts-soar`](https://huggingface.co/rednote-hilab/dots.tts-soar) | Self-corrective-aligned (SCA) checkpoint on top of `dots.tts-base`. Best voice cloning performance. | `10`–`32` (default `10`) |
-| [`rednote-hilab/dots.tts-mf`](https://huggingface.co/rednote-hilab/dots.tts-mf) | MeanFlow-distilled student from `dots.tts-soar`. Recommended if you care about inference speed. | `4` |
+| [`rednote-hilab/dots.tts-mf`](https://huggingface.co/rednote-hilab/dots.tts-mf) | MeanFlow-distilled student from `dots.tts-soar`. Not recommended. | NFE `4` |
+| [`rednote-hilab/dots.tts-rl`](https://huggingface.co/rednote-hilab/dots.tts-rl) | Reinforcement-learning post-trained checkpoint. Recommended for one-step inference. | NFE `1` |
+| [`rednote-hilab/dots.tts-scm-2step`](https://huggingface.co/rednote-hilab/dots.tts-scm-2step) | sCM-distilled checkpoint. Recommended for two-step inference. | NFE `2` |
+
+For fast inference, we recommend `dots.tts-rl` for one-step generation or `dots.tts-scm-2step` for two-step generation.
 
 Pass the repo id directly to `--model-name-or-path` (or `DotsTtsRuntime.from_pretrained`) — the snapshot is fetched on first use and cached locally.
 
@@ -125,14 +129,33 @@ dots.tts \
   --text "Hello, this is a quick speech synthesis test." \
   --num-steps 10 \
   --output output.wav
+
+# One-step inference with the RL checkpoint
+dots.tts \
+  --model-name-or-path rednote-hilab/dots.tts-rl \
+  --text "Hello, this is a one-step synthesis test." \
+  --prompt-audio /path/to/reference.wav \
+  --prompt-text "The exact transcript of the reference audio." \
+  --ode-method euler \
+  --num-steps 1 \
+  --guidance-scale 0 \
+  --output rl.wav
+
+# Two-step inference with the sCM checkpoint
+dots.tts \
+  --model-name-or-path rednote-hilab/dots.tts-scm-2step \
+  --text "Hello, this is a two-step synthesis test." \
+  --prompt-audio /path/to/reference.wav \
+  --prompt-text "The exact transcript of the reference audio." \
+  --output scm.wav
 ```
 
 Common flags:
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--num-steps` | Flow-matching sampling steps (higher = better quality, lower = faster) | `10` |
-| `--guidance-scale` | CFG scale (flow-matching only; MeanFlow has CFG fused into the student; values > 2 progressively amplify audio energy) | `1.2` |
+| `--num-steps` | Sampling steps. Uses an artifact-declared value when present; otherwise `10`. | artifact / `10` |
+| `--guidance-scale` | CFG scale. Uses an artifact-declared value when present; otherwise `1.2`. | artifact / `1.2` |
 | `--normalize-text` | Apply text normalization before inference (via [WeTextProcessing](https://github.com/wenet-e2e/WeTextProcessing)) | off |
 | `--language` | Add an explicit language tag to the input text; accepts `none`, `auto_detect`, language codes such as `EN` / `ZH`, or names such as `english` / `chinese` | `none` |
 | `--seed` | RNG seed (fixed seed → deterministic output) | `42` |
@@ -167,6 +190,9 @@ result = runtime.generate(
 
 sf.write("output.wav", result["audio"].float().cpu().squeeze().numpy(), result["sample_rate"])
 ```
+
+For an sCM artifact, omit `num_steps` and `guidance_scale`; `generate` and
+`generate_stream` read the required two-step/CFG=0 settings from the artifact.
 
 For low-latency playback or streaming to a client, use `generate_stream` instead — it yields audio chunks (`torch.Tensor`, shape `(1, samples)`) as they are produced. Arguments are identical to `generate`:
 
@@ -279,7 +305,7 @@ Common MeanFlow flags:
 - **`--prompt-text` should match what's actually spoken in the reference audio**. Mismatches degrade stability and may cause word-level errors.
 - **Higher-quality references give better clones** — prefer a high sample rate, low background noise, no trailing noise, and natural-sounding speech.
 - **Try different `--seed` values for prosody variation**. Each seed produces a different rhythm and intonation — resample a few times if the default doesn't feel right.
-- **Increase `--num-steps` if quality isn't good enough**. More sampling steps trade compute for cleaner output and better expressiveness.
+- **For flow-matching checkpoints, increase `--num-steps` if quality isn't good enough**. Artifact-locked solvers such as two-step sCM reject incompatible step counts.
 - **Force a pronunciation with Pinyin for polyphones.** Replace the character in the input text with its tone-marked pinyin — e.g. write `我生平不hào此道` to force `好` to be read as `hào`. Use tone-marked pinyin only (`hǎo`, `hào`, `bā`); numbered forms like `hao4` or `ha4o` are **not** recognized. Useful when reseeding doesn't fix a polyphone misread.
 
 ---
@@ -320,6 +346,8 @@ Zero-shot, ~3 s reference prompt, scored by the benchmark's reference ASR and Wa
 | **dots.tts (Pretrain)** | **2B** | 1.34 / 76.8 | 0.96 / 80.5 | 6.46 / 79.2 | **2.92** / 78.8 |
 | **dots.tts (SCA)** | **2B** | 1.30 / **77.1** | 0.94 / **81.0** | 6.60 / **79.5** | 2.95 / **79.2** |
 | **dots.tts (MF, NFE=4)** | **2B** | 1.29 / 76.2 | 0.94 / 80.0 | 6.60 / 78.5 | 2.94 / 78.2 |
+| **dots.tts (RL, NFE=1)** | **2B** | 1.49 / 76.5 | 1.06 / 80.2 | 6.54 / 78.2 | 3.03 / 78.3 |
+| **dots.tts (sCM, NFE=2)** | **2B** | 1.49 / 76.5 | 0.97 / 80.3 | 6.53 / 78.8 | 3.00 / 78.5 |
 
 ### MiniMax Multilingual (24 languages)
 

--- a/apps/gradio/app.py
+++ b/apps/gradio/app.py
@@ -22,7 +22,6 @@ from apps.gradio.constants import (  # noqa: E402
     DEFAULT_LOG_FILE,
     DEFAULT_MAX_GENERATE_LENGTH,
     DEFAULT_NUM_STEPS,
-    DEFAULT_ODE_METHOD,
     DEFAULT_OUTPUT_DIR,
     DEFAULT_OUTPUT_RETENTION,
     DEFAULT_PORT,
@@ -393,6 +392,9 @@ def build_demo(gr, app_config, app_service) -> "gr.Blocks":
         resolve_prompt_selection,
     )
 
+    sampling_controls = app_service.sampling_controls()
+    sampling_locked = bool(sampling_controls["locked"])
+
     def select_prompt_preset(prompt_name: str):
         audio_path, prompt_text = resolve_prompt_selection(
             prompt_name,
@@ -494,21 +496,29 @@ def build_demo(gr, app_config, app_service) -> "gr.Blocks":
                     elem_classes="strong-label",
                 )
                 with gr.Accordion("⚙️ Settings", open=False, elem_classes="settings-card"):
+                    if sampling_locked:
+                        gr.Textbox(
+                            label="Solver",
+                            value=str(sampling_controls["solver"]),
+                            interactive=False,
+                        )
                     with gr.Row(elem_classes="settings-slider-row"):
                         num_steps = gr.Slider(
                             label="Num Steps",
                             minimum=1,
                             maximum=32,
                             step=1,
-                            value=app_config.default_num_steps,
+                            value=sampling_controls["num_steps"],
+                            interactive=not sampling_locked,
                         )
                     with gr.Row(elem_classes="settings-slider-row"):
                         guidance_scale = gr.Slider(
                             label="Guidance Scale",
-                            minimum=1.0,
+                            minimum=0.0 if sampling_locked else 1.0,
                             maximum=3.0,
                             step=0.1,
-                            value=app_config.default_guidance_scale,
+                            value=sampling_controls["guidance_scale"],
+                            interactive=not sampling_locked,
                         )
                     with gr.Row(elem_classes="control-row"):
                         seed = gr.Number(
@@ -546,8 +556,9 @@ def build_demo(gr, app_config, app_service) -> "gr.Blocks":
                 )
                 ode_method = gr.Textbox(
                     label="ODE Method",
-                    value=DEFAULT_ODE_METHOD,
+                    value=sampling_controls["ode_method"],
                     lines=1,
+                    interactive=not sampling_locked,
                 )
                 speaker_scale = gr.Slider(
                     label="Speaker Scale",
@@ -561,7 +572,7 @@ def build_demo(gr, app_config, app_service) -> "gr.Blocks":
                 build_startup_config_panel(gr, app_config)
         else:
             synthesis_mode = gr.State(value="tts")
-            ode_method = gr.State(value=DEFAULT_ODE_METHOD)
+            ode_method = gr.State(value=sampling_controls["ode_method"])
             speaker_scale = gr.State(value=app_config.default_speaker_scale)
             metrics = gr.State(value={})
 

--- a/apps/gradio/service.py
+++ b/apps/gradio/service.py
@@ -460,6 +460,29 @@ class GradioAppService:
             )
         return self._runtime, resolved_model_name_or_path
 
+    def sampling_controls(self) -> dict[str, Any]:
+        """Return the fixed model's artifact-resolved sampling UI contract."""
+
+        runtime, _resolved_model_name_or_path = self._get_runtime(
+            self.config.default_model_name_or_path
+        )
+        sampling = runtime.model.config.sampling
+        if sampling is None:
+            return {
+                "solver": runtime.model.core.mode,
+                "locked": False,
+                "ode_method": DEFAULT_ODE_METHOD,
+                "num_steps": self.config.default_num_steps,
+                "guidance_scale": self.config.default_guidance_scale,
+            }
+        return {
+            "solver": sampling.solver,
+            "locked": True,
+            "ode_method": sampling.ode_method,
+            "num_steps": sampling.num_steps,
+            "guidance_scale": sampling.guidance_scale,
+        }
+
     def _build_stream_request_id(
         self,
         runtime: DotsTtsRuntime,
@@ -557,14 +580,21 @@ class GradioAppService:
                 runtime, resolved_model_name_or_path = self._get_runtime(
                     self.config.default_model_name_or_path,
                 )
+                ode_method, num_steps, guidance_scale = (
+                    runtime.resolve_sampling_options(
+                        ode_method=None,
+                        num_steps=None,
+                        guidance_scale=None,
+                    )
+                )
                 warmup_request = SynthesisRequest(
                     model_name_or_path=self.config.default_model_name_or_path,
                     text=warmup_text,
                     execution_mode=self.config.execution_mode,
                     template_name="tts",
-                    ode_method=DEFAULT_ODE_METHOD,
-                    num_steps=self.config.default_num_steps,
-                    guidance_scale=self.config.default_guidance_scale,
+                    ode_method=ode_method,
+                    num_steps=num_steps,
+                    guidance_scale=guidance_scale,
                     speaker_scale=self.config.default_speaker_scale,
                     normalize_text=False,
                     seed=DEFAULT_SEED,

--- a/scripts/example_double_streaming.py
+++ b/scripts/example_double_streaming.py
@@ -16,10 +16,10 @@ import soundfile as sf  # noqa: E402
 import torch  # noqa: E402
 from loguru import logger  # noqa: E402
 
-from dots_tts.utils.logging import configure_logging  # noqa: E402
 from dots_tts.runtime_double_streaming import (  # noqa: E402
     DotsTtsRuntimeDoubleStreaming,
 )
+from dots_tts.utils.logging import configure_logging  # noqa: E402
 from dots_tts.utils.text import normalize_text  # noqa: E402
 from dots_tts.utils.util import seed_everything  # noqa: E402
 
@@ -54,13 +54,22 @@ def parse_args(argv=None):
         default=42,
         help="Random seed.",
     )
-    parser.add_argument("--ode-method", default="euler", help="ODE solver method")
-    parser.add_argument("--num-steps", type=int, default=10, help="Diffusion sampling steps")
+    parser.add_argument(
+        "--ode-method",
+        default=None,
+        help="ODE solver method (default: artifact setting, otherwise euler)",
+    )
+    parser.add_argument(
+        "--num-steps",
+        type=int,
+        default=None,
+        help="Sampling steps (default: artifact setting, otherwise 10)",
+    )
     parser.add_argument(
         "--guidance-scale",
         type=float,
-        default=1.2,
-        help="Classifier-free guidance scale",
+        default=None,
+        help="Classifier-free guidance scale (default: artifact setting, otherwise 1.2)",
     )
     parser.add_argument(
         "--eos-threshold",

--- a/src/dots_tts/cli.py
+++ b/src/dots_tts/cli.py
@@ -48,16 +48,22 @@ def parse_args(argv=None):
         help="Named template preset for generation.",
     )
     parser.add_argument(
-        "--ode-method", type=str, default="euler", help="ODE solver method"
+        "--ode-method",
+        type=str,
+        default=None,
+        help="ODE solver method (default: artifact setting, otherwise euler)",
     )
     parser.add_argument(
-        "--num-steps", type=int, default=10, help="Diffusion sampling steps"
+        "--num-steps",
+        type=int,
+        default=None,
+        help="Sampling steps (default: artifact setting, otherwise 10)",
     )
     parser.add_argument(
         "--guidance-scale",
         type=float,
-        default=1.2,
-        help="Classifier-free guidance scale",
+        default=None,
+        help="Classifier-free guidance scale (default: artifact setting, otherwise 1.2)",
     )
     parser.add_argument(
         "--speaker-scale",

--- a/src/dots_tts/models/dots_tts/config.py
+++ b/src/dots_tts/models/dots_tts/config.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import math
+from typing import Literal
+
+from pydantic import Field
+
 from dots_tts.config.base import ConfigBase, StrictConfigBase
 from dots_tts.modules.vocoder.config import AudioVAEConfig
 
@@ -49,6 +54,37 @@ class MeanFlowConfig(ConfigBase):
     use_duration_embedding: bool = True
 
 
+class SamplingConfig(StrictConfigBase):
+    solver: Literal["scm"]
+    ode_method: Literal["euler"] = "euler"
+    num_steps: Literal[2] = 2
+    guidance_scale: Literal[0.0] = 0.0
+    tau_mid: float = Field(default=1.3, gt=0.0, lt=math.pi / 2)
+
+    def resolve(
+        self,
+        *,
+        ode_method: str | None,
+        num_steps: int | None,
+        guidance_scale: float | None,
+    ) -> tuple[str, int, float]:
+        expected = (self.ode_method, self.num_steps, self.guidance_scale)
+        resolved = (
+            self.ode_method if ode_method is None else str(ode_method),
+            self.num_steps if num_steps is None else int(num_steps),
+            self.guidance_scale if guidance_scale is None else float(guidance_scale),
+        )
+        if resolved != expected:
+            raise ValueError(
+                f"{self.solver} artifact requires "
+                f"ode_method={expected[0]!r}, num_steps={expected[1]}, "
+                f"guidance_scale={expected[2]}; got "
+                f"ode_method={resolved[0]!r}, num_steps={resolved[1]}, "
+                f"guidance_scale={resolved[2]}."
+            )
+        return resolved
+
+
 class ModelConfig(ConfigBase):
     model_type: str = "dots_tts"
     latent_dim: int
@@ -62,10 +98,12 @@ class ModelConfig(ConfigBase):
     campplus_embedding_size: int | None = 512
     xvec_max_audio_seconds: float = 10.0
     meanflow: MeanFlowConfig | None = None
+    sampling: SamplingConfig | None = None
 
 
 __all__ = [
     "LossConfig",
     "MeanFlowConfig",
     "ModelConfig",
+    "SamplingConfig",
 ]

--- a/src/dots_tts/models/dots_tts/model.py
+++ b/src/dots_tts/models/dots_tts/model.py
@@ -28,6 +28,7 @@ from dots_tts.modules.backbone.encoder_inference import (
     SemanticEncoderInference,
 )
 from dots_tts.modules.backbone.llm_inference import LLMInference, LLMInferenceState
+from dots_tts.modules.backbone.scm_inference import SCMDiTSolver
 from dots_tts.modules.speaker.encoder import SpeakerXVectorFeatures
 from dots_tts.modules.vocoder.bigvgan import AudioVAE
 from dots_tts.modules.vocoder.vocoder_inference import VocoderInference
@@ -745,19 +746,33 @@ class DotsTtsModel(nn.Module):
             self._llm_inference_core_id = core_id
         return adapter
 
-    def _get_dit_solver(self, *, meanflow: bool) -> DiTSolver:
+    def _get_dit_solver(self, *, solver_mode: str) -> DiTSolver:
         key = (
-            "meanflow" if meanflow else "flow_matching",
+            solver_mode,
             bool(self._optimize_enabled),
         )
         solver = self._fm_dit_solvers.get(key)
         if solver is None:
-            solver = DiTSolver(
-                DiTInferenceContext.from_core(self.core),
-                optimize=self._optimize_enabled,
-                bucket_resolver=self._resolve_generate_length_bucket,
-                meanflow=meanflow,
-            )
+            context = DiTInferenceContext.from_core(self.core)
+            if solver_mode == "scm":
+                sampling = self.config.sampling
+                if sampling is None:
+                    raise RuntimeError("sCM solver requires artifact sampling config.")
+                solver = SCMDiTSolver(
+                    context,
+                    optimize=self._optimize_enabled,
+                    bucket_resolver=self._resolve_generate_length_bucket,
+                    tau_mid=sampling.tau_mid,
+                )
+            elif solver_mode in {"flow_matching", "meanflow"}:
+                solver = DiTSolver(
+                    context,
+                    optimize=self._optimize_enabled,
+                    bucket_resolver=self._resolve_generate_length_bucket,
+                    meanflow=solver_mode == "meanflow",
+                )
+            else:
+                raise ValueError(f"Unsupported DiT solver mode: {solver_mode!r}.")
             self._fm_dit_solvers[key] = solver
         return solver
 
@@ -1196,14 +1211,21 @@ class DotsTtsModel(nn.Module):
             null_g_cond = state.fm_null_g_cond
             if null_g_cond is None:
                 raise RuntimeError("FM null conditioning buffer is not initialized.")
-            meanflow = self.core.mode == "meanflow"
+            sampling = self.config.sampling
+            if sampling is not None:
+                sampling.resolve(
+                    ode_method=ode_method,
+                    num_steps=num_steps,
+                    guidance_scale=guidance_scale,
+                )
+            solver_mode = "scm" if sampling is not None else self.core.mode
             cfg_sequence = state.fm_cfg_sequence
-            if not meanflow and cfg_sequence is None:
+            if solver_mode == "flow_matching" and cfg_sequence is None:
                 raise RuntimeError("FM cfg static buffer is not initialized.")
-            audio_patch = self._get_dit_solver(meanflow=meanflow).decode_next(
+            audio_patch = self._get_dit_solver(solver_mode=solver_mode).decode_next(
                 state.fm_dit_state,
                 sequence=sequence,
-                cfg_sequence=cfg_sequence,
+                cfg_sequence=None if solver_mode == "scm" else cfg_sequence,
                 fm_seq_len=state.fm_seq_len,
                 null_g_cond=null_g_cond,
                 g_cond=g_cond,
@@ -1595,5 +1617,3 @@ class DotsTtsModel(nn.Module):
         return audio
 
     # endregion Public generation APIs
-
-

--- a/src/dots_tts/modules/backbone/dit_inference.py
+++ b/src/dots_tts/modules/backbone/dit_inference.py
@@ -1239,13 +1239,17 @@ class EagerDiTRunner:
 # --------------------------------------------------------------------------- #
 
 
-def _resolve_kv_attention_backend(*, optimize: bool, on_cuda: bool) -> str:
+def _resolve_kv_attention_backend(
+    *, optimize: bool, on_cuda: bool, default_backend: str | None = None
+) -> str:
     """Pick the KV-cache attention backend (flex vs sdpa) from env / device."""
     if not optimize:
         return "sdpa"
     env = os.environ.get("DOTS_TTS_DELAYED_DIT_BACKEND")
     if env is None:
-        return "flex" if on_cuda else "sdpa"
+        if default_backend is None:
+            return "flex" if on_cuda else "sdpa"
+        env = default_backend
     env = env.lower()
     if env not in {"sdpa", "flex"}:
         raise ValueError(
@@ -1677,7 +1681,7 @@ class DiTSolver:
                 kv_cache=kv_cache,
                 prefix_sequence=sequence[:, :persistent_len],
                 cfg_prefix_sequence=(
-                    None if self.meanflow else cfg_sequence[:, :persistent_len]  # type: ignore[index]
+                    None if cfg_sequence is None else cfg_sequence[:, :persistent_len]
                 ),
                 all_mods_by_ode=all_mods_by_ode,
             )

--- a/src/dots_tts/modules/backbone/scm_inference.py
+++ b/src/dots_tts/modules/backbone/scm_inference.py
@@ -1,0 +1,268 @@
+"""Inference-only sCM support for two-step artifacts."""
+
+from __future__ import annotations
+
+import math
+from typing import Callable
+
+import torch
+
+from dots_tts.modules.backbone.dit_inference import (
+    FLOW_MATCHING_MODE,
+    DiTInferenceContext,
+    DiTSolver,
+    EagerDiTRunner,
+    ODESchedule,
+    _resolve_kv_attention_backend,
+)
+
+
+def _broadcast(values: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    return values.reshape(-1, *([1] * (target.ndim - 1)))
+
+
+def _coefficients(
+    tau: torch.Tensor, fm_sigma: float
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    tau = tau.float()
+    cos_tau = torch.cos(tau)
+    sin_tau = torch.sin(tau)
+    residual_scale = 1.0 - fm_sigma
+    scale = sin_tau + residual_scale * cos_tau
+    scale_derivative = cos_tau - residual_scale * sin_tau
+    return cos_tau, sin_tau, scale, scale_derivative
+
+
+def _to_flow_matching(
+    x_tau: torch.Tensor, tau: torch.Tensor, fm_sigma: float
+) -> tuple[torch.Tensor, torch.Tensor]:
+    cos_tau, _sin_tau, scale, _scale_derivative = _coefficients(tau, fm_sigma)
+    return x_tau.float() / _broadcast(scale, x_tau), cos_tau / scale
+
+
+def _denoise(
+    flow_state: torch.Tensor,
+    flow_velocity: torch.Tensor,
+    tau: torch.Tensor,
+    fm_sigma: float,
+) -> torch.Tensor:
+    cos_tau, sin_tau, scale, scale_derivative = _coefficients(tau, fm_sigma)
+    x_tau = _broadcast(scale, flow_state) * flow_state.float()
+    trig_velocity = _broadcast(
+        scale_derivative, flow_state
+    ) * flow_state.float() - flow_velocity.float() / _broadcast(scale, flow_state)
+    return (
+        _broadcast(cos_tau, x_tau) * x_tau - _broadcast(sin_tau, x_tau) * trig_velocity
+    )
+
+
+def _renoise(denoised: torch.Tensor, tau: torch.Tensor) -> torch.Tensor:
+    return _broadcast(torch.cos(tau), denoised) * denoised + _broadcast(
+        torch.sin(tau), denoised
+    ) * torch.randn_like(denoised)
+
+
+def _tau_grid(tau_mid: float, device: torch.device) -> torch.Tensor:
+    return torch.tensor(
+        [math.pi / 2, tau_mid],
+        device=device,
+        dtype=torch.float32,
+    )
+
+
+class _SCMSchedule(ODESchedule):
+    """Two-step TrigFlow denoise/re-noise schedule."""
+
+    def __init__(self, taus: torch.Tensor, flow_times: torch.Tensor, fm_sigma: float):
+        super().__init__(mode=FLOW_MATCHING_MODE, times=flow_times)
+        self.taus = taus
+        self.fm_sigma = fm_sigma
+
+    def advance(
+        self,
+        flow_state: torch.Tensor,
+        flow_velocity: torch.Tensor,
+        *,
+        ode_idx: int,
+        batch_size: int,
+        flow_dt: torch.Tensor | None,
+    ) -> torch.Tensor:
+        del batch_size, flow_dt
+        tau = self.taus[ode_idx].expand(flow_state.size(0))
+        denoised = _denoise(
+            flow_state,
+            flow_velocity,
+            tau,
+            self.fm_sigma,
+        )
+        if ode_idx == self.taus.numel() - 1:
+            return denoised.to(dtype=flow_state.dtype)
+
+        next_tau = self.taus[ode_idx + 1].expand(flow_state.size(0))
+        next_x_tau = _renoise(denoised, next_tau)
+        next_flow_state, _next_flow_time = _to_flow_matching(
+            next_x_tau,
+            next_tau,
+            self.fm_sigma,
+        )
+        return next_flow_state.to(dtype=flow_state.dtype)
+
+
+class _SCMEagerDiTRunner(EagerDiTRunner):
+    """Full-compute sCM runner used when optimization is disabled."""
+
+    def __init__(self, *, context: DiTInferenceContext, tau_mid: float):
+        super().__init__(context=context)
+        self.tau_mid = tau_mid
+
+    def _velocity(
+        self,
+        t: torch.Tensor,
+        flow_state: torch.Tensor,
+        *,
+        input_sequence: torch.Tensor,
+        attn_mask: torch.Tensor,
+        pos_ids: torch.Tensor,
+        g_cond: torch.Tensor,
+    ) -> torch.Tensor:
+        latent_start = input_sequence.size(1) - self.latent_patch_size
+        x = self._splat_noise(self.coordinate_proj(flow_state), input_sequence)
+        return self.dit(
+            x=x,
+            timesteps=t.reshape(1).expand(x.size(0)),
+            attn_mask=attn_mask,
+            pos_ids=pos_ids,
+            g_cond=g_cond.to(device=x.device, dtype=x.dtype),
+        )[:, latent_start:]
+
+    def decode_next(
+        self,
+        *,
+        sequence: torch.Tensor,
+        fm_seq_len: int,
+        g_cond: torch.Tensor,
+        nfe: int,
+        meanflow: bool,
+        cfg_sequence: torch.Tensor | None = None,
+        guidance_scale: float | None = None,
+        ode_method: str = "euler",
+    ) -> torch.Tensor:
+        del nfe, meanflow, cfg_sequence, guidance_scale, ode_method
+        input_sequence, _cfg_input, attn_mask, pos_ids = self._prepare_inputs(
+            sequence=sequence,
+            fm_seq_len=fm_seq_len,
+        )
+        taus = _tau_grid(self.tau_mid, sequence.device)
+        x_tau = torch.randn(
+            (sequence.size(0), self.latent_patch_size, self.latent_dim),
+            dtype=sequence.dtype,
+            device=sequence.device,
+        )
+
+        for ode_idx in range(taus.numel()):
+            tau = taus[ode_idx].expand(sequence.size(0))
+            flow_state, flow_time = _to_flow_matching(x_tau, tau, self.fm_sigma)
+            flow_velocity = self._velocity(
+                flow_time[0],
+                flow_state.to(dtype=sequence.dtype),
+                input_sequence=input_sequence,
+                attn_mask=attn_mask,
+                pos_ids=pos_ids,
+                g_cond=g_cond,
+            )
+            denoised = _denoise(
+                flow_state,
+                flow_velocity,
+                tau,
+                self.fm_sigma,
+            )
+            if ode_idx == taus.numel() - 1:
+                return denoised.to(dtype=sequence.dtype)
+            next_tau = taus[ode_idx + 1].expand(sequence.size(0))
+            x_tau = _renoise(denoised, next_tau).to(dtype=sequence.dtype)
+        raise AssertionError("unreachable sCM sampling loop")
+
+
+class SCMDiTSolver(DiTSolver):
+    """Two-step sCM solver for eager and KV-cache inference."""
+
+    def __init__(
+        self,
+        context: DiTInferenceContext,
+        *,
+        optimize: bool,
+        bucket_resolver: Callable[[int], int],
+        tau_mid: float,
+    ):
+        if not 0.0 < tau_mid < math.pi / 2:
+            raise ValueError("tau_mid must lie strictly inside (0, pi/2)")
+        if not 0.0 <= context.fm_sigma < 1.0:
+            raise ValueError("fm_sigma must lie inside [0, 1)")
+        super().__init__(
+            context,
+            optimize=optimize,
+            bucket_resolver=bucket_resolver,
+        )
+        self.branch_multiplier = 1
+        self.tau_mid = tau_mid
+
+    def _backend_for(self, device: torch.device) -> str:
+        key = device.type
+        if key not in self._backend_by_device_type:
+            self._backend_by_device_type[key] = _resolve_kv_attention_backend(
+                optimize=self.optimize,
+                on_cuda=key == "cuda",
+                default_backend="sdpa",
+            )
+        return self._backend_by_device_type[key]
+
+    def _get_eager_runner(
+        self, *, device: torch.device, dtype: torch.dtype
+    ) -> _SCMEagerDiTRunner:
+        key = (str(device), dtype)
+        runner = self._eager_runners.get(key)
+        if runner is None:
+            runner = _SCMEagerDiTRunner(context=self.context, tau_mid=self.tau_mid)
+            self._eager_runners[key] = runner
+        return runner
+
+    def _validate_decode_args(
+        self,
+        *,
+        fm_seq_len: int,
+        nfe: int,
+        cfg_sequence: torch.Tensor | None,
+        guidance_scale: float | None,
+    ) -> None:
+        del cfg_sequence
+        if fm_seq_len <= 0:
+            raise RuntimeError(
+                "Cannot decode audio before any conditioning state has been prefetched."
+            )
+        if nfe != 2:
+            raise ValueError(f"sCM requires nfe=2, got {nfe}")
+        if guidance_scale is None or guidance_scale != 0.0:
+            raise ValueError("sCM requires guidance_scale=0")
+
+    def _prepare_schedule_flow_matching(
+        self, *, g_cond: torch.Tensor, nfe: int
+    ) -> tuple[torch.Tensor, _SCMSchedule]:
+        del nfe
+        taus = _tau_grid(self.tau_mid, g_cond.device)
+        dummy = torch.zeros(2, 1, 1, device=g_cond.device)
+        _flow_state, flow_times = _to_flow_matching(
+            dummy,
+            taus,
+            self.context.fm_sigma,
+        )
+
+        dit = self.context.dit
+        with torch.no_grad():
+            time_inputs = flow_times[:, None].expand(2, g_cond.size(0)).reshape(-1)
+            condition = dit.time_embedder(time_inputs.to(dtype=g_cond.dtype))
+            g_flat = g_cond[None].expand(2, -1, -1).reshape(2 * g_cond.size(0), -1)
+            mods = dit.fused_adaln(condition + g_flat)
+        return (
+            mods.reshape(2, g_cond.size(0), -1),
+            _SCMSchedule(taus, flow_times, self.context.fm_sigma),
+        )

--- a/src/dots_tts/runtime.py
+++ b/src/dots_tts/runtime.py
@@ -320,12 +320,24 @@ class DotsTtsRuntime:
         # VOCODER_STREAM_INITIAL_UNMERGED_PATCHES chunks are 1 patch each,
         # subsequent chunks are vocoder_merge_steps patches each.
         initial_unmerged = int(self.model.VOCODER_STREAM_INITIAL_UNMERGED_PATCHES)
+        if self.model.config.sampling is not None:
+            warmup_ode_method, warmup_num_steps, warmup_guidance_scale = (
+                self.resolve_sampling_options(
+                    ode_method=None,
+                    num_steps=None,
+                    guidance_scale=None,
+                )
+            )
+        else:
+            warmup_ode_method = "euler"
+            warmup_num_steps = self.WARMUP_NUM_STEPS
+            warmup_guidance_scale = 1.2
         stream = self.model.generate_audio_stream(
             inputs,
             precision=self.precision,
-            ode_method="euler",
-            num_steps=self.WARMUP_NUM_STEPS,
-            guidance_scale=1.2,
+            ode_method=warmup_ode_method,
+            num_steps=warmup_num_steps,
+            guidance_scale=warmup_guidance_scale,
             speaker_scale=1.5,
             eos_threshold=self.WARMUP_EOS_THRESHOLD,
             vocoder_merge_steps=self.vocoder_merge_steps,
@@ -650,6 +662,28 @@ class DotsTtsRuntime:
     # endregion Generation schedule assembly
 
     # region Public generation APIs
+    def resolve_sampling_options(
+        self,
+        *,
+        ode_method: str | None,
+        num_steps: int | None,
+        guidance_scale: float | None,
+    ) -> tuple[str, int, float]:
+        """Apply artifact defaults and reject overrides of locked contracts."""
+
+        sampling = self.model.config.sampling
+        if sampling is not None:
+            return sampling.resolve(
+                ode_method=ode_method,
+                num_steps=num_steps,
+                guidance_scale=guidance_scale,
+            )
+        return (
+            "euler" if ode_method is None else str(ode_method),
+            10 if num_steps is None else int(num_steps),
+            1.2 if guidance_scale is None else float(guidance_scale),
+        )
+
     def generate_stream(
         self,
         *,
@@ -659,13 +693,18 @@ class DotsTtsRuntime:
         template_name: str | None = None,
         language: str | None = None,
         speaker_scale: float = 1.5,
-        ode_method: str = "euler",
-        num_steps: int = 10,
-        guidance_scale: float = 1.2,
+        ode_method: str | None = None,
+        num_steps: int | None = None,
+        guidance_scale: float | None = None,
         normalize_text: bool = False,
         profile_inference: bool = False,
         log_profile_calls: bool = False,
     ) -> Iterator[torch.Tensor]:
+        ode_method, num_steps, guidance_scale = self.resolve_sampling_options(
+            ode_method=ode_method,
+            num_steps=num_steps,
+            guidance_scale=guidance_scale,
+        )
         inputs = self._prepare_inputs(
             text=text,
             prompt_audio_path=prompt_audio_path,
@@ -768,13 +807,18 @@ class DotsTtsRuntime:
         template_name: str | None = None,
         language: str | None = None,
         speaker_scale: float = 1.5,
-        ode_method: str = "euler",
-        num_steps: int = 10,
-        guidance_scale: float = 1.2,
+        ode_method: str | None = None,
+        num_steps: int | None = None,
+        guidance_scale: float | None = None,
         normalize_text: bool = False,
         profile_inference: bool = False,
         log_profile_calls: bool = False,
     ) -> dict[str, Any]:
+        ode_method, num_steps, guidance_scale = self.resolve_sampling_options(
+            ode_method=ode_method,
+            num_steps=num_steps,
+            guidance_scale=guidance_scale,
+        )
         inputs = self._prepare_inputs(
             text=text,
             prompt_audio_path=prompt_audio_path,

--- a/src/dots_tts/runtime_double_streaming.py
+++ b/src/dots_tts/runtime_double_streaming.py
@@ -23,9 +23,9 @@ class DoubleStreamingSession:
         prompt_audio_path: str | None = None,
         prompt_text: str | None = None,
         template_name: str = "tts_interleave",
-        ode_method: str = "euler",
-        num_steps: int = 10,
-        guidance_scale: float = 1.2,
+        ode_method: str | None = None,
+        num_steps: int | None = None,
+        guidance_scale: float | None = None,
         speaker_scale: float = 1.5,
         eos_threshold: float = 0.8,
         initial_silence_audio_tokens: int | None = None,
@@ -41,6 +41,11 @@ class DoubleStreamingSession:
                 "tts_interleave double streaming does not support prompt_text."
             )
 
+        ode_method, num_steps, guidance_scale = runtime.resolve_sampling_options(
+            ode_method=ode_method,
+            num_steps=num_steps,
+            guidance_scale=guidance_scale,
+        )
         self.runtime = runtime
         self.model = runtime.model
         self.device = runtime.device
@@ -376,9 +381,9 @@ class DotsTtsRuntimeDoubleStreaming(DotsTtsRuntime):
         prompt_audio_path: str | None = None,
         prompt_text: str | None = None,
         template_name: str = "tts_interleave",
-        ode_method: str = "euler",
-        num_steps: int = 10,
-        guidance_scale: float = 1.2,
+        ode_method: str | None = None,
+        num_steps: int | None = None,
+        guidance_scale: float | None = None,
         speaker_scale: float = 1.5,
         eos_threshold: float = 0.8,
         initial_silence_audio_tokens: int | None = None,


### PR DESCRIPTION
## Summary

- add native two-step sCM sampling with the artifact-declared Euler / NFE=2 / CFG=0 contract and `tau_mid`
- route artifact sampling defaults through the CLI, Gradio, standard runtime, and double-streaming runtime while preserving existing flow-matching behavior
- document the recommended one-step RL and two-step sCM checkpoints, inference commands, and Seed-TTS-Eval WER/SIM results

## Why

This prepares the public dots.tts runtime for the new two-step sCM artifact. The solver is selected from `config.json`, and incompatible sampling overrides fail explicitly instead of silently changing the artifact recipe.

## Validation

- `ruff check` on all modified Python files
- Python `compileall` on the modified application, script, and package sources
- `git diff --check`
- strict SHA256 verification of both complete Hugging Face artifacts
- end-to-end Taozi inference on NVIDIA L20Z:
  - RL artifact: Euler, NFE=1, CFG=0
  - sCM artifact: artifact-selected native sCM, NFE=2, CFG=0
  - four fixed prompt-conditioned cases per artifact
  - all outputs verified as mono 48 kHz PCM16 with matching remote/local checksums
