### PR TITLE
Add paired-prompt double streaming + README org-link/SOAR updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/rednote-hilab/dots.tts"><img src="https://img.shields.io/badge/GitHub-rednote--hilab%2Fdots.tts-blue?logo=github" alt="GitHub"></a>
-  <a href="https://huggingface.co/collections/rednote-hilab/dotstts"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-dots.tts%20collection-yellow" alt="Hugging Face"></a>
+  <a href="https://github.com/studio-dots-ai/dots.tts"><img src="https://img.shields.io/badge/GitHub-studio--dots--ai%2Fdots.tts-blue?logo=github" alt="GitHub"></a>
+  <a href="https://huggingface.co/collections/dots-studio/dotstts"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-dots.tts%20collection-yellow" alt="Hugging Face"></a>
   <a href="https://arxiv.org/abs/2606.07080"><img src="https://img.shields.io/badge/arXiv-Report-b31b1b?logo=arxiv&logoColor=white" alt="arXiv"></a>
-  <a href="https://huggingface.co/spaces/rednote-hilab/dots.tts"><img src="https://img.shields.io/badge/Playground-Live-orange" alt="Playground"></a>
-  <a href="https://rednote-hilab.github.io/dots.tts-demo/"><img src="https://img.shields.io/badge/Demo%20Page-Live-red" alt="Demo Page"></a>
+  <a href="https://huggingface.co/spaces/dots-studio/dots.tts"><img src="https://img.shields.io/badge/Playground-Live-orange" alt="Playground"></a>
+  <a href="https://studio-dots-ai.github.io/dots.tts-demo/"><img src="https://img.shields.io/badge/Demo%20Page-Live-red" alt="Demo Page"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-green" alt="License"></a>
 </p>
 
@@ -72,7 +72,7 @@ pip install dots.tts
 Or from source (for local development / editable install):
 
 ```bash
-git clone https://github.com/rednote-hilab/dots.tts
+git clone https://github.com/studio-dots-ai/dots.tts
 cd dots.tts
 pip install -e . -c constraints/recommended.txt
 ```
@@ -108,11 +108,11 @@ Five pretrained checkpoints are released on Hugging Face. All five share the sam
 
 | Model | Description | Inference settings |
 |---|---|:---:|
-| [`rednote-hilab/dots.tts-base`](https://huggingface.co/rednote-hilab/dots.tts-base) | Pretrained checkpoint. | `10`–`32` (default `10`) |
-| [`rednote-hilab/dots.tts-soar`](https://huggingface.co/rednote-hilab/dots.tts-soar) | Self-corrective-aligned (SCA) checkpoint on top of `dots.tts-base`. Best voice cloning performance. | `10`–`32` (default `10`) |
-| [`rednote-hilab/dots.tts-mf`](https://huggingface.co/rednote-hilab/dots.tts-mf) | MeanFlow-distilled student from `dots.tts-soar`. Not recommended. | NFE `4` |
-| [`rednote-hilab/dots.tts-rl`](https://huggingface.co/rednote-hilab/dots.tts-rl) | Reinforcement-learning post-trained checkpoint. Recommended for one-step inference. | NFE `1` |
-| [`rednote-hilab/dots.tts-scm-2step`](https://huggingface.co/rednote-hilab/dots.tts-scm-2step) | sCM-distilled checkpoint. Recommended for two-step inference. | NFE `2` |
+| [`dots-studio/dots.tts-base`](https://huggingface.co/dots-studio/dots.tts-base) | Pretrained checkpoint. | `10`–`32` (default `10`) |
+| [`dots-studio/dots.tts-soar`](https://huggingface.co/dots-studio/dots.tts-soar) | Self-corrective-aligned (SOAR) checkpoint on top of `dots.tts-base`. Best voice cloning performance. | `10`–`32` (default `10`) |
+| [`dots-studio/dots.tts-mf`](https://huggingface.co/dots-studio/dots.tts-mf) | MeanFlow-distilled student from `dots.tts-soar`. Not recommended. | NFE `4` |
+| [`dots-studio/dots.tts-rl`](https://huggingface.co/dots-studio/dots.tts-rl) | Reinforcement-learning post-trained checkpoint. Recommended for one-step inference. | NFE `1` |
+| [`dots-studio/dots.tts-scm-2step`](https://huggingface.co/dots-studio/dots.tts-scm-2step) | sCM-distilled checkpoint. Recommended for two-step inference. | NFE `2` |
 
 For fast inference, we recommend `dots.tts-rl` for one-step generation or `dots.tts-scm-2step` for two-step generation.
 
@@ -125,7 +125,7 @@ The package installs a `dots.tts` entry point:
 ```bash
 # Continuation voice cloning (reference audio + transcript) — recommended, best SIM
 dots.tts \
-  --model-name-or-path rednote-hilab/dots.tts-soar \
+  --model-name-or-path dots-studio/dots.tts-soar \
   --text "Hello, this is a zero-shot voice cloning demonstration." \
   --prompt-audio /path/to/reference.wav \
   --prompt-text "The exact transcript of the reference audio." \
@@ -134,7 +134,7 @@ dots.tts \
 
 # X-vector-only voice cloning (reference audio only — timbre from speaker x-vector)
 dots.tts \
-  --model-name-or-path rednote-hilab/dots.tts-soar \
+  --model-name-or-path dots-studio/dots.tts-soar \
   --text "Hello, this is a zero-shot voice cloning demonstration." \
   --prompt-audio /path/to/reference.wav \
   --num-steps 10 \
@@ -143,14 +143,14 @@ dots.tts \
 # Random-voice sampling (no reference) — only meaningful with a fine-tuned
 # single-speaker checkpoint
 dots.tts \
-  --model-name-or-path rednote-hilab/dots.tts-soar \
+  --model-name-or-path dots-studio/dots.tts-soar \
   --text "Hello, this is a quick speech synthesis test." \
   --num-steps 10 \
   --output output.wav
 
 # One-step inference with the RL checkpoint
 dots.tts \
-  --model-name-or-path rednote-hilab/dots.tts-rl \
+  --model-name-or-path dots-studio/dots.tts-rl \
   --text "Hello, this is a one-step synthesis test." \
   --prompt-audio /path/to/reference.wav \
   --prompt-text "The exact transcript of the reference audio." \
@@ -161,7 +161,7 @@ dots.tts \
 
 # Two-step inference with the sCM checkpoint
 dots.tts \
-  --model-name-or-path rednote-hilab/dots.tts-scm-2step \
+  --model-name-or-path dots-studio/dots.tts-scm-2step \
   --text "Hello, this is a two-step synthesis test." \
   --prompt-audio /path/to/reference.wav \
   --prompt-text "The exact transcript of the reference audio." \
@@ -193,7 +193,7 @@ from dots_tts.runtime import DotsTtsRuntime
 import soundfile as sf
 
 runtime = DotsTtsRuntime.from_pretrained(
-    "rednote-hilab/dots.tts-soar",
+    "dots-studio/dots.tts-soar",
     precision="bfloat16",
     optimize=True,  # torch.compile acceleration (warmup at load, faster steady-state)
 )
@@ -238,7 +238,7 @@ sf.write("output_stream.wav", audio, runtime.sample_rate)
 
 ```bash
 python apps/gradio/app.py \
-  --model-name-or-path rednote-hilab/dots.tts-soar \
+  --model-name-or-path dots-studio/dots.tts-soar \
   --optimize
 ```
 
@@ -273,7 +273,7 @@ MeanFlow distillation trains a MeanFlow DiT student against a frozen flow-matchi
 To use SOAR as the teacher, download it first:
 
 ```bash
-huggingface-cli download rednote-hilab/dots.tts-soar \
+huggingface-cli download dots-studio/dots.tts-soar \
   --local-dir pretrained_models/dots.tts-soar
 ```
 
@@ -338,7 +338,7 @@ sgl-omni serve \
 | [`dots-studio/dots.tts-soar`](https://huggingface.co/dots-studio/dots.tts-soar) | `examples/configs/dots_tts_soar.yaml` | Flow matching + CFG. Single request at a time (`max_running_requests=1`), `num_steps=10`. |
 | [`dots-studio/dots.tts-base`](https://huggingface.co/dots-studio/dots.tts-base) | `examples/configs/dots_tts_soar.yaml` | Same as SOAR; pass `--model-path dots-studio/dots.tts-base`. |
 
-`rednote-hilab/dots.tts-*` weights are interchangeable via `--model-path`. Use the config file — it enables the compiled acoustic tail / vocoder and backbone decode CUDA graph. Continuous batching is MeanFlow-only.
+`dots-studio/dots.tts-*` weights are interchangeable via `--model-path`. Use the config file — it enables the compiled acoustic tail / vocoder and backbone decode CUDA graph. Continuous batching is MeanFlow-only.
 
 Voice cloning (reference audio + transcript required):
 
@@ -447,19 +447,19 @@ Zero-shot, ~3 s reference prompt, scored by the benchmark's reference ASR and Wa
 | VibeVoice | 1.5B | 3.04 / 68.9 | 1.16 / 74.4 | — | — |
 | VoxCPM 2 | 2B | 1.84 / 75.3 | 0.97 / 79.5 | 8.13 / 75.3 | 3.65 / 76.7 |
 | **dots.tts (Pretrain)** | **2B** | 1.34 / 76.8 | 0.96 / 80.5 | 6.46 / 79.2 | **2.92** / 78.8 |
-| **dots.tts (SCA)** | **2B** | 1.30 / **77.1** | 0.94 / **81.0** | 6.60 / **79.5** | 2.95 / **79.2** |
+| **dots.tts (SOAR)** | **2B** | 1.30 / **77.1** | 0.94 / **81.0** | 6.60 / **79.5** | 2.95 / **79.2** |
 | **dots.tts (MF, NFE=4)** | **2B** | 1.29 / 76.2 | 0.94 / 80.0 | 6.60 / 78.5 | 2.94 / 78.2 |
 | **dots.tts (RL, NFE=1)** | **2B** | 1.49 / 76.5 | 1.06 / 80.2 | 6.54 / 78.2 | 3.03 / 78.3 |
 | **dots.tts (sCM, NFE=2)** | **2B** | 1.49 / 76.5 | 0.97 / 80.3 | 6.53 / 78.8 | 3.00 / 78.5 |
 
 ### MiniMax Multilingual (24 languages)
 
-Per-language WER / SIM on the MiniMax-Speech multilingual test set (100 utterances × 2 reference speakers per language). **Highest average SIM (83.9, SCA)**, with a dots.tts variant taking the per-language SIM lead outright on 19 of 24 languages and tying on 2 more. Content fidelity is on par with the strongest systems on high-resource / Western European splits, and trails on low-resource long-tail languages where SIM is still preserved.
+Per-language WER / SIM on the MiniMax-Speech multilingual test set (100 utterances × 2 reference speakers per language). **Highest average SIM (83.9, SOAR)**, with a dots.tts variant taking the per-language SIM lead outright on 19 of 24 languages and tying on 2 more. Content fidelity is on par with the strongest systems on high-resource / Western European splits, and trails on low-resource long-tail languages where SIM is still preserved.
 
 <details>
 <summary><b>Per-language WER / SIM (click to expand)</b></summary>
 
-| Language | MiniMax | ElevenLabs | Fish-Audio S2 | VoxCPM 2 | **dots.tts (Pre.)** | **dots.tts (SCA)** | **dots.tts (MF$_4$)** |
+| Language | MiniMax | ElevenLabs | Fish-Audio S2 | VoxCPM 2 | **dots.tts (Pre.)** | **dots.tts (SOAR)** | **dots.tts (MF$_4$)** |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | Arabic | **1.67** / 73.6 | **1.67** / 70.6 | 3.50 / 75.0 | 13.05 / **79.1** | 37.91 / 77.5 | 36.19 / **79.1** | 39.65 / 77.6 |
 | Cantonese* | 34.11 / 77.8 | 51.51 / 67.0 | 30.67 / 80.5 | 38.58 / 83.5 | 37.91 / 84.7 | 42.32 / **85.0** | 37.82 / 84.0 |
@@ -493,7 +493,7 @@ Per-language WER / SIM on the MiniMax-Speech multilingual test set (100 utteranc
 
 ### CV3-Eval
 
-Hard-subset Chinese/English plus a cross-lingual voice-cloning split. **Takes the table top on hard-en (MF$_4$ at 4.37) and leads both cross-lingual SIM subsets (SCA at 75.0 / 72.8)**, with the post-trained variants bracketing the prior leader on the hardest English subset.
+Hard-subset Chinese/English plus a cross-lingual voice-cloning split. **Takes the table top on hard-en (MF$_4$ at 4.37) and leads both cross-lingual SIM subsets (SOAR at 75.0 / 72.8)**, with the post-trained variants bracketing the prior leader on the hardest English subset.
 
 | Model | zh W↓ | en W↓ | hard-zh W↓ | hard-en W↓ | en→zh W↓ / S↑ | zh→en W↓ / S↑ |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|
@@ -502,12 +502,12 @@ Hard-subset Chinese/English plus a cross-lingual voice-cloning split. **Takes th
 | Fish-Audio S2 | **2.65** | **2.43** | 9.10 | 4.40 | — | — |
 | VoxCPM 2 | 3.65 | 5.00 | **8.55** | 8.48 | — | — |
 | **dots.tts (Pretrain)** | 3.51 | 5.24 | 9.69 | 5.99 | 10.88 / 74.6 | 4.97 / 71.9 |
-| **dots.tts (SCA)** | 3.71 | 4.50 | 9.22 | 4.49 | 10.75 / **75.0** | 5.66 / **72.8** |
+| **dots.tts (SOAR)** | 3.71 | 4.50 | 9.22 | 4.49 | 10.75 / **75.0** | 5.66 / **72.8** |
 | **dots.tts (MF, NFE=4)** | 3.95 | 4.05 | 9.10 | **4.37** | 10.73 / 73.8 | 5.24 / 70.9 |
 
 ### EmergentTTS-Eval
 
-Win-rate judged head-to-head against `gpt-4o-mini-tts` by Gemini-2.5-Pro-0506 across six expressiveness-oriented scenarios. **SCA takes the top Syntactic Complexity score in the table (65.7%) — above every closed-source system** — and Pretrain posts the **best Emotions score among open-source systems (72.7%)**.
+Win-rate judged head-to-head against `gpt-4o-mini-tts` by Gemini-2.5-Pro-0506 across six expressiveness-oriented scenarios. **SOAR takes the top Syntactic Complexity score in the table (65.7%) — above every closed-source system** — and Pretrain posts the **best Emotions score among open-source systems (72.7%)**.
 
 | Model | Voice | WER↓ | Overall↑ | Emotions↑ | Paraling.↑ | Foreign↑ | C. Pron.↑ | Quest.↑ | Syntax↑ |
 |---|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
@@ -518,7 +518,7 @@ Win-rate judged head-to-head against `gpt-4o-mini-tts` by Gemini-2.5-Pro-0506 ac
 | *baseline: gpt-4o-mini-tts* | Alloy | 10.61 | 50.0% | — | — | — | — | — | — |
 | **dots.tts (Pretrain)** | basic\_ref\_en | 10.86 | 49.2% | 72.7% | 54.7% | 39.5% | 18.0% | 48.4% | 58.4% |
 | **dots.tts (MF4)** | basic\_ref\_en | 11.75 | 47.9% | 59.8% | 55.2% | 36.3% | 16.7% | 50.5% | 64.8% |
-| **dots.tts (SCA)** | basic\_ref\_en | 10.45 | 47.6% | 63.9% | 52.7% | 39.4% | 16.4% | 47.0% | **65.7%** |
+| **dots.tts (SOAR)** | basic\_ref\_en | 10.45 | 47.6% | 63.9% | 52.7% | 39.4% | 16.4% | 47.0% | **65.7%** |
 | Qwen3-TTS | basic\_ref\_en | 17.32 | 42.8% | 39.8% | 50.7% | 25.4% | 30.0% | 48.9% | 60.4% |
 | HumeAI\* | — | 12.85 | 42.7% | 61.6% | 36.9% | 34.6% | 34.3% | 43.2% | 44.6% |
 | Qwen3-TTS | Ryan | 19.65 | 42.3% | 60.5% | 62.7% | 17.1% | 9.8% | 56.4% | 43.0% |

--- a/scripts/example_double_streaming.py
+++ b/scripts/example_double_streaming.py
@@ -34,14 +34,28 @@ def parse_args(argv=None):
         help="Local pretrained directory or Hugging Face repo id",
     )
     parser.add_argument("--text", required=True, help="Input text")
-    parser.add_argument("--output", default="double_streaming.wav", help="Output wav path")
+    parser.add_argument(
+        "--output", default="double_streaming.wav", help="Output wav path"
+    )
     parser.add_argument(
         "--prompt-audio",
         default=None,
         help="Optional reference audio for ref_audio_only speaker conditioning",
     )
-    parser.add_argument("--revision", default=None, help="Optional Hugging Face revision")
-    parser.add_argument("--cache-dir", default=None, help="Optional Hugging Face cache dir")
+    parser.add_argument(
+        "--prompt-text",
+        default=None,
+        help=(
+            "Optional reference audio transcript. When used with --prompt-audio, "
+            "double streaming automatically uses tts_interleave_pair."
+        ),
+    )
+    parser.add_argument(
+        "--revision", default=None, help="Optional Hugging Face revision"
+    )
+    parser.add_argument(
+        "--cache-dir", default=None, help="Optional Hugging Face cache dir"
+    )
     parser.add_argument("--precision", default="bfloat16", help="Inference precision")
     parser.add_argument(
         "--optimize",
@@ -84,6 +98,33 @@ def parse_args(argv=None):
         help="Maximum number of decoded audio patches in double streaming",
     )
     parser.add_argument(
+        "--interleave-mode",
+        choices=("one_to_one", "buffered_ratio"),
+        default=None,
+        help=(
+            "Override online interleave mode. Defaults to the checkpoint training "
+            "config when available, otherwise one_to_one."
+        ),
+    )
+    parser.add_argument(
+        "--initial-lookahead",
+        type=int,
+        default=None,
+        help="Override buffered-ratio first audio text-token lookahead.",
+    )
+    parser.add_argument(
+        "--warmup-ta",
+        type=int,
+        default=None,
+        help="Override buffered-ratio warmup TA steps.",
+    )
+    parser.add_argument(
+        "--ta-per-tta",
+        type=int,
+        default=None,
+        help="Override buffered-ratio steady cycle TA count per TTA step.",
+    )
+    parser.add_argument(
         "--normalize-text",
         action="store_true",
         help="Normalize text before tokenizer encode",
@@ -104,6 +145,8 @@ def main(argv=None):
     configure_logging()
     args = parse_args(argv)
     seed_everything(args.seed)
+    if args.prompt_text and not args.prompt_audio:
+        raise ValueError("--prompt-text requires --prompt-audio.")
 
     output_path = Path(args.output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -133,20 +176,34 @@ def main(argv=None):
 
     session = runtime.start_double_streaming(
         prompt_audio_path=args.prompt_audio,
+        prompt_text=args.prompt_text,
         ode_method=args.ode_method,
         num_steps=args.num_steps,
         guidance_scale=args.guidance_scale,
         eos_threshold=args.eos_threshold,
+        interleave_mode=args.interleave_mode,
+        initial_lookahead=args.initial_lookahead,
+        warmup_ta=args.warmup_ta,
+        ta_per_tta=args.ta_per_tta,
+    )
+    logger.info(
+        "Double streaming session: template_name={} interleave_mode={} "
+        "initial_lookahead={} warmup_ta={} ta_per_tta={}",
+        session.template_name,
+        session.interleave_mode,
+        session.initial_lookahead,
+        session.warmup_ta,
+        session.ta_per_tta,
     )
 
     chunks: list[torch.Tensor] = []
     for index, token_id in enumerate(text_token_ids, start=1):
         chunk = session.push_text_token(token_id)
         logger.info(
-            "Double streaming step: token_index={} token_id={} emitted_audio={}",
+            "Double streaming step: token_index={} token_id={} event={}",
             index,
             token_id,
-            chunk is not None,
+            "audio" if chunk is not None else "wait",
         )
         if chunk is not None:
             chunks.append(chunk.detach().cpu())

--- a/src/dots_tts/runtime_double_streaming.py
+++ b/src/dots_tts/runtime_double_streaming.py
@@ -1,16 +1,170 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import torch
+import yaml
 from loguru import logger
 
 from dots_tts.data.pipelines.tts_pipeline import TTS_INTERLEAVE_PREFIX
 from dots_tts.runtime import DotsTtsRuntime
 from dots_tts.utils.logging import categorized_log as logc
+from dots_tts.utils.tokenizer import (
+    AUDIO_GEN_END_TOKEN,
+    AUDIO_GEN_SPAN_TOKEN,
+    TEXT_COND_END_TOKEN,
+    require_token_id,
+)
 from dots_tts.utils.util import get_dtype
 
-DOUBLE_STREAMING_TEMPLATE_NAMES = frozenset({"tts_interleave"})
+PAIR_DOUBLE_STREAMING_TEMPLATE_NAME = "tts_interleave_pair"
+DOUBLE_STREAMING_TEMPLATE_NAMES = frozenset(
+    {"tts_interleave", PAIR_DOUBLE_STREAMING_TEMPLATE_NAME}
+)
+INTERLEAVE_MODE_ONE_TO_ONE = "one_to_one"
+INTERLEAVE_MODE_BUFFERED_RATIO = "buffered_ratio"
+INTERLEAVE_MODES = frozenset(
+    {INTERLEAVE_MODE_ONE_TO_ONE, INTERLEAVE_MODE_BUFFERED_RATIO}
+)
+DEFAULT_INTERLEAVE_PATTERN = (INTERLEAVE_MODE_ONE_TO_ONE, None, 2, 1)
+
+
+def _walk_mappings(value: Any):
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from _walk_mappings(child)
+        return
+    if isinstance(value, list):
+        for child in value:
+            yield from _walk_mappings(child)
+
+
+def _load_interleave_pattern_from_training_config(
+    pretrained_path: Path,
+) -> tuple[str, int | None, int, int] | None:
+    for parent in (pretrained_path, *pretrained_path.parents):
+        config_path = parent / "config.yml"
+        if not config_path.is_file():
+            continue
+        try:
+            with config_path.open("r", encoding="utf-8") as fin:
+                config = yaml.safe_load(fin)
+        except Exception as exc:  # pragma: no cover - defensive config fallback
+            logger.warning(
+                logc(
+                    "stream",
+                    "Failed to read double streaming interleave config: path={} error={}",
+                ),
+                config_path,
+                exc,
+            )
+            return None
+        for mapping in _walk_mappings(config):
+            mode = mapping.get("interleave_mode")
+            if mode not in INTERLEAVE_MODES:
+                continue
+            return (
+                str(mode),
+                mapping.get("initial_lookahead"),
+                int(mapping.get("ta_per_tta", 2)),
+                int(mapping.get("warmup_ta", 1)),
+            )
+        return None
+    return None
+
+
+def normalize_interleave_pattern(
+    *,
+    interleave_mode: str = INTERLEAVE_MODE_ONE_TO_ONE,
+    initial_lookahead: int | None = None,
+    ta_per_tta: int = 2,
+    warmup_ta: int = 1,
+) -> tuple[str, int, int, int]:
+    if interleave_mode not in INTERLEAVE_MODES:
+        raise ValueError(
+            f"Unknown interleave_mode={interleave_mode!r}. "
+            f"Expected one of {sorted(INTERLEAVE_MODES)}."
+        )
+    if interleave_mode == INTERLEAVE_MODE_ONE_TO_ONE:
+        return interleave_mode, 1, 0, 0
+
+    lookahead = 3 if initial_lookahead is None else int(initial_lookahead)
+    ta_count = int(ta_per_tta)
+    warmup_count = int(warmup_ta)
+    if lookahead <= 0:
+        raise ValueError("initial_lookahead must be positive.")
+    if ta_count <= 0:
+        raise ValueError("ta_per_tta must be positive for buffered_ratio.")
+    if warmup_count < 0:
+        raise ValueError("warmup_ta must be non-negative.")
+    return interleave_mode, lookahead, ta_count, warmup_count
+
+
+def interleave_text_quota(
+    audio_index: int,
+    *,
+    interleave_mode: str = INTERLEAVE_MODE_ONE_TO_ONE,
+    initial_lookahead: int | None = None,
+    ta_per_tta: int = 2,
+    warmup_ta: int = 1,
+) -> int:
+    mode, lookahead, ta_count, warmup_count = normalize_interleave_pattern(
+        interleave_mode=interleave_mode,
+        initial_lookahead=initial_lookahead,
+        ta_per_tta=ta_per_tta,
+        warmup_ta=warmup_ta,
+    )
+    if mode == INTERLEAVE_MODE_ONE_TO_ONE:
+        return 1
+    if int(audio_index) == 0:
+        return lookahead
+    steady_index = int(audio_index) - 1
+    if steady_index < warmup_count:
+        return 1
+    return 2 if (steady_index - warmup_count) % (ta_count + 1) == ta_count else 1
+
+
+def build_interleave_token_sequence(
+    *,
+    text_tokens: list[int],
+    audio_tokens: list[int],
+    text_cond_end_id: int,
+    interleave_mode: str = INTERLEAVE_MODE_ONE_TO_ONE,
+    initial_lookahead: int | None = None,
+    ta_per_tta: int = 2,
+    warmup_ta: int = 1,
+) -> list[int]:
+    token_ids: list[int] = []
+    text_index = 0
+    text_cond_end_added = False
+
+    for audio_index, audio_token in enumerate(audio_tokens):
+        quota = interleave_text_quota(
+            audio_index,
+            interleave_mode=interleave_mode,
+            initial_lookahead=initial_lookahead,
+            ta_per_tta=ta_per_tta,
+            warmup_ta=warmup_ta,
+        )
+        had_text = text_index < len(text_tokens)
+        for _ in range(quota):
+            if text_index >= len(text_tokens):
+                break
+            token_ids.append(text_tokens[text_index])
+            text_index += 1
+        if not had_text and not text_cond_end_added:
+            token_ids.append(text_cond_end_id)
+            text_cond_end_added = True
+        token_ids.append(audio_token)
+
+    while text_index < len(text_tokens):
+        token_ids.append(text_tokens[text_index])
+        text_index += 1
+    if not text_cond_end_added:
+        token_ids.append(text_cond_end_id)
+    return token_ids
 
 
 class DoubleStreamingSession:
@@ -29,14 +183,29 @@ class DoubleStreamingSession:
         speaker_scale: float = 1.5,
         eos_threshold: float = 0.8,
         initial_silence_audio_tokens: int | None = None,
+        interleave_mode: str | None = None,
+        initial_lookahead: int | None = None,
+        ta_per_tta: int | None = None,
+        warmup_ta: int | None = None,
     ) -> None:
         normalized_prompt_text = runtime._process_prompt_text(prompt_text)
+        if (
+            template_name == "tts_interleave"
+            and prompt_audio_path is not None
+            and normalized_prompt_text
+        ):
+            template_name = PAIR_DOUBLE_STREAMING_TEMPLATE_NAME
         if template_name not in DOUBLE_STREAMING_TEMPLATE_NAMES:
             raise ValueError(
                 f"Unknown double streaming template_name={template_name!r}. "
                 f"Expected one of {sorted(DOUBLE_STREAMING_TEMPLATE_NAMES)}."
             )
-        if normalized_prompt_text:
+        if template_name == PAIR_DOUBLE_STREAMING_TEMPLATE_NAME:
+            if prompt_audio_path is None:
+                raise ValueError("tts_interleave_pair requires prompt_audio_path.")
+            if not normalized_prompt_text:
+                raise ValueError("tts_interleave_pair requires prompt_text.")
+        elif normalized_prompt_text:
             raise ValueError(
                 "tts_interleave double streaming does not support prompt_text."
             )
@@ -56,8 +225,29 @@ class DoubleStreamingSession:
         self.speaker_scale = float(speaker_scale)
         self.eos_threshold = float(eos_threshold)
         self.max_generate_length = runtime.max_generate_length
+        config_pattern = (
+            _load_interleave_pattern_from_training_config(runtime.pretrained_path)
+            or DEFAULT_INTERLEAVE_PATTERN
+        )
+        (
+            self.interleave_mode,
+            self.initial_lookahead,
+            self.ta_per_tta,
+            self.warmup_ta,
+        ) = normalize_interleave_pattern(
+            interleave_mode=interleave_mode or config_pattern[0],
+            initial_lookahead=(
+                initial_lookahead
+                if initial_lookahead is not None
+                else config_pattern[1]
+            ),
+            ta_per_tta=ta_per_tta if ta_per_tta is not None else config_pattern[2],
+            warmup_ta=warmup_ta if warmup_ta is not None else config_pattern[3],
+        )
         if initial_silence_audio_tokens is None:
-            initial_silence_audio_tokens = 1
+            initial_silence_audio_tokens = (
+                0 if template_name == PAIR_DOUBLE_STREAMING_TEMPLATE_NAME else 1
+            )
         self._initial_silence_audio_tokens = max(
             0,
             min(10, int(initial_silence_audio_tokens or 0)),
@@ -90,8 +280,15 @@ class DoubleStreamingSession:
         self._text_finished = False
         self._closed = False
         self._decoded_patch_count = 0
+        self._text_token_buffer: list[int] = []
+        self._debug_audio_events: list[str] = []
 
-        if prompt_audio_path is not None:
+        if template_name == PAIR_DOUBLE_STREAMING_TEMPLATE_NAME:
+            self._prefill_pair_prompt(
+                prompt_audio_path=prompt_audio_path,
+                prompt_text=normalized_prompt_text,
+            )
+        elif prompt_audio_path is not None:
             self._prepare_ref_audio_only_conditioning(prompt_audio_path)
 
         logger.debug(
@@ -99,7 +296,8 @@ class DoubleStreamingSession:
                 "stream",
                 "Double streaming session started: template_name={} prefix_token_count={} precision={} "
                 "ode_method={} num_steps={} guidance_scale={} speaker_scale={} max_audio_patch_count={} "
-                "initial_silence_audio_tokens={} has_ref_audio_only={}",
+                "initial_silence_audio_tokens={} interleave_mode={} initial_lookahead={} "
+                "ta_per_tta={} warmup_ta={} has_ref_audio_only={}",
             ),
             self.template_name,
             len(self._prefix_token_ids),
@@ -110,7 +308,12 @@ class DoubleStreamingSession:
             self.speaker_scale,
             self.max_generate_length,
             self._initial_silence_audio_tokens,
-            self._g_cond is not None,
+            self.interleave_mode,
+            self.initial_lookahead,
+            self.ta_per_tta,
+            self.warmup_ta,
+            self._g_cond is not None
+            and self.template_name != PAIR_DOUBLE_STREAMING_TEMPLATE_NAME,
         )
 
     @property
@@ -128,14 +331,21 @@ class DoubleStreamingSession:
             )
 
         token_id = int(text_token)
-        if not self._started:
-            chunk_token_ids = [*self._pending_token_ids, token_id]
-            self._pending_token_ids.clear()
-            self._started = True
-        else:
-            chunk_token_ids = [token_id]
+        self._text_token_buffer.append(token_id)
+        quota = interleave_text_quota(
+            self._decoded_patch_count,
+            interleave_mode=self.interleave_mode,
+            initial_lookahead=self.initial_lookahead,
+            ta_per_tta=self.ta_per_tta,
+            warmup_ta=self.warmup_ta,
+        )
+        if len(self._text_token_buffer) < quota:
+            self._debug_audio_events.append("wait")
+            return None
 
+        chunk_token_ids = self._pop_text_chunk(quota)
         self._consume_text_chunk(chunk_token_ids)
+        self._debug_audio_events.append("audio")
         return self._decode_audio_chunk()
 
     def finish_text(self):
@@ -143,7 +353,11 @@ class DoubleStreamingSession:
 
         if not self._state.end_flag:
             if not self._text_finished:
-                text_end_chunk = [self.model.core.text_cond_end_id]
+                text_end_chunk = [
+                    *self._text_token_buffer,
+                    self.model.core.text_cond_end_id,
+                ]
+                self._text_token_buffer.clear()
                 if not self._started:
                     text_end_chunk = [*self._pending_token_ids, *text_end_chunk]
                     self._pending_token_ids.clear()
@@ -170,6 +384,15 @@ class DoubleStreamingSession:
     def _ensure_active(self) -> None:
         if self._closed:
             raise RuntimeError("Double streaming session is already closed.")
+
+    def _pop_text_chunk(self, quota: int) -> list[int]:
+        chunk_token_ids = self._text_token_buffer[:quota]
+        del self._text_token_buffer[:quota]
+        if not self._started:
+            chunk_token_ids = [*self._pending_token_ids, *chunk_token_ids]
+            self._pending_token_ids.clear()
+            self._started = True
+        return chunk_token_ids
 
     def _prepare_ref_audio_only_conditioning(self, prompt_audio_path: str) -> None:
         cache = getattr(self.runtime, "_double_streaming_prompt_g_cond_cache", None)
@@ -222,6 +445,122 @@ class DoubleStreamingSession:
                 self.speaker_scale,
             )
         self._g_cond = cached_g_cond
+
+    def _prefill_pair_prompt(
+        self,
+        *,
+        prompt_audio_path: str | None,
+        prompt_text: str,
+    ) -> None:
+        if prompt_audio_path is None:
+            raise ValueError("tts_interleave_pair requires prompt_audio_path.")
+        prompt_audio = self.runtime._load_prompt_audio(prompt_audio_path)
+        with torch.no_grad():
+            with torch.autocast(
+                device_type=self.device.type,
+                dtype=self._dtype,
+                enabled=self._use_amp,
+            ):
+                prompt_conditioning = self.model._prepare_prompt_conditioning(
+                    prompt_audio,
+                    use_prompt_prefill=True,
+                    speaker_scale=self.speaker_scale,
+                )
+                if (
+                    prompt_conditioning.prompt_patches is None
+                    or prompt_conditioning.prompt_latents is None
+                ):
+                    raise RuntimeError(
+                        "tts_interleave_pair prompt prefill did not produce prompt latents."
+                    )
+                prompt_patch_count = int(prompt_conditioning.prompt_patches.size(1))
+                prompt_audio_span_count = prompt_patch_count + 1
+                if self.max_generate_length <= prompt_audio_span_count:
+                    raise ValueError(
+                        "max_generate_length must exceed prompt audio span count for "
+                        "tts_interleave_pair double streaming: "
+                        f"max_generate_length={self.max_generate_length} "
+                        f"prompt_audio_span_count={prompt_audio_span_count}."
+                    )
+                prompt_schedule = self._build_pair_prompt_schedule(
+                    prompt_text=prompt_text,
+                    prompt_audio_span_count=prompt_audio_span_count,
+                )
+                audio_placeholder_ids = set(self.model.core.audio_span_token_ids)
+                span_positions = self.model._find_audio_span_positions(
+                    prompt_schedule,
+                    audio_placeholder_ids=audio_placeholder_ids,
+                )
+                prompt_patch_embeddings = self.model._prefill_prompt_latents(
+                    prompt_conditioning.prompt_latents,
+                    state=self._state,
+                )
+                tail_position = self.model._prefill(
+                    prompt_schedule,
+                    state=self._state,
+                    span_positions=span_positions,
+                    prompt_patches=prompt_conditioning.prompt_patches,
+                    prompt_patch_embeddings=prompt_patch_embeddings,
+                    audio_placeholder_ids=audio_placeholder_ids,
+                )
+                prompt_tail_patch = self.model._decode_next_audio(
+                    self._state,
+                    g_cond=prompt_conditioning.g_cond,
+                    ode_method=self.ode_method,
+                    num_steps=self.num_steps,
+                    guidance_scale=self.guidance_scale,
+                )
+                self.model._consume_audio_patch(
+                    self._state,
+                    audio_patch=prompt_tail_patch,
+                )
+
+        self._g_cond = (
+            None
+            if prompt_conditioning.g_cond is None
+            else prompt_conditioning.g_cond.detach()
+        )
+        self._pending_token_ids = [
+            *prompt_schedule[0, tail_position + 1 :].tolist(),
+            *self._prefix_token_ids,
+        ]
+        self.max_generate_length -= prompt_audio_span_count
+        logger.debug(
+            logc(
+                "conditioning",
+                "Double streaming pair prompt prefetched: prompt_audio_span_count={} "
+                "target_max_audio_patch_count={} pending_token_count={}",
+            ),
+            prompt_audio_span_count,
+            self.max_generate_length,
+            len(self._pending_token_ids),
+        )
+
+    def _build_pair_prompt_schedule(
+        self,
+        *,
+        prompt_text: str,
+        prompt_audio_span_count: int,
+    ) -> torch.Tensor:
+        tokenizer = self.model.tokenizer
+        audio_span_id = require_token_id(tokenizer, AUDIO_GEN_SPAN_TOKEN)
+        audio_end_id = require_token_id(tokenizer, AUDIO_GEN_END_TOKEN)
+        text_cond_end_id = require_token_id(tokenizer, TEXT_COND_END_TOKEN)
+        prompt_text_tokens = tokenizer.encode(prompt_text, add_special_tokens=False)
+        audio_tokens = [audio_span_id] * int(prompt_audio_span_count) + [audio_end_id]
+        token_ids = list(self._prefix_token_ids)
+        token_ids.extend(
+            build_interleave_token_sequence(
+                text_tokens=prompt_text_tokens,
+                audio_tokens=audio_tokens,
+                text_cond_end_id=text_cond_end_id,
+                interleave_mode=self.interleave_mode,
+                initial_lookahead=self.initial_lookahead,
+                ta_per_tta=self.ta_per_tta,
+                warmup_ta=self.warmup_ta,
+            )
+        )
+        return torch.tensor([token_ids], dtype=torch.long, device=self.device)
 
     def _consume_text_chunk(self, token_ids: list[int]) -> None:
         schedule = torch.tensor(
@@ -337,9 +676,13 @@ class DoubleStreamingSession:
                 dtype=self._dtype,
                 enabled=self._use_amp,
             ):
-                stop_after_current_audio = self.model._should_stop_after_current_audio(
-                    self._state,
-                    eos_threshold=self.eos_threshold,
+                stop_after_current_audio = (
+                    self.model._should_stop_after_current_audio(
+                        self._state,
+                        eos_threshold=self.eos_threshold,
+                    )
+                    if self._text_finished
+                    else False
                 )
                 audio_patch = self.model._decode_next_audio(
                     self._state,
@@ -387,6 +730,10 @@ class DotsTtsRuntimeDoubleStreaming(DotsTtsRuntime):
         speaker_scale: float = 1.5,
         eos_threshold: float = 0.8,
         initial_silence_audio_tokens: int | None = None,
+        interleave_mode: str | None = None,
+        initial_lookahead: int | None = None,
+        ta_per_tta: int | None = None,
+        warmup_ta: int | None = None,
     ) -> DoubleStreamingSession:
         return DoubleStreamingSession(
             self,
@@ -399,6 +746,10 @@ class DotsTtsRuntimeDoubleStreaming(DotsTtsRuntime):
             speaker_scale=speaker_scale,
             eos_threshold=eos_threshold,
             initial_silence_audio_tokens=initial_silence_audio_tokens,
+            interleave_mode=interleave_mode,
+            initial_lookahead=initial_lookahead,
+            ta_per_tta=ta_per_tta,
+            warmup_ta=warmup_ta,
         )
 
 


### PR DESCRIPTION
## Summary
- **Double streaming: paired prompt + buffered-ratio interleave** — Add the `tts_interleave_pair` template so double streaming can consume a reference audio *and* its transcript together, plus a configurable buffered-ratio interleave strategy (`interleave_mode` / `initial_lookahead` / `ta_per_tta` / `warmup_ta`). Values are read from the checkpoint training config when available, or overridden via new CLI flags in `example_double_streaming.py`.
- **README maintenance** — Migrate all org links to the new upstream: `studio-dots-ai` on GitHub and `dots-studio` on Hugging Face (the old GitHub demo page 404s; other old links only worked via redirect). Also unify the checkpoint variant label from **SCA** to **SOAR** across the model table and all benchmark tables.

## Notes
- The sampling-option contract (`runtime.resolve_sampling_options`) is preserved — the new code keeps `ode_method` / `num_steps` / `guidance_scale` defaulting to `None` and resolving through the runtime.
- No changes to public defaults for the existing `tts_interleave` path.

## Testing
- `python -m py_compile` passes on both changed Python files.
- `ruff check` passes on both changed Python files.
- All updated README links verified to return HTTP 200 (incl. the previously-404 demo page).