### PR TITLE
Add config-driven double-streaming inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ dots.tts achieves the best average performance on **Seed-TTS-Eval**, with WERs o
 
 * **[2026.08]** 🔥 We have released **dots.tts.edit** for precise, instruction-controlled speech editing — download the [checkpoint](https://huggingface.co/dots-studio/dots.tts.edit), try the [Playground](https://dots-studio-dots-tts-edit.hf.space/), explore the [Demo Page](https://dots-studio-dots-tts-edit-demo.static.hf.space), and read the [paper](https://arxiv.org/abs/2608.02673).
 
-* **[2026.08]** ⚡ Released `dots.tts-mf-2steps` and `dots.tts-mf-1step` for high-quality voice cloning at just 2 and 1 NFE. Both build on `dots.tts-mf` with fixed-step train–inference alignment. See [Checkpoints](#checkpoints).
+* **[2026.08]** ⚡ Released `dots.tts-mf-2steps`, `dots.tts-mf-1step`, and `dots.tts-mf-2steps-stts` for high-quality voice cloning and double-streaming TTS. These checkpoints build on `dots.tts-mf` with fixed-step train–inference alignment. See [Checkpoints](#checkpoints).
 
 * **[2026.08]** 🚀 [SGLang Omni](https://github.com/sgl-project/sglang-omni) now fully supports dots.tts (`mf` / `soar` / `base`) with continuous batching, streaming PCM, and CUDA-graph decode. On Seed-TTS-Eval **EN** (1× H100, `dots.tts-mf`, `num_steps=4`), peak throughput reaches **4.64 req/s** / **19.36 audio_s/s** at concurrency 16 (WER **1.31%**). See [SGLang Omni Usage](#sglang-omni-usage) and the [cookbook](https://sgl-project.github.io/sglang-omni/cookbook/dots_tts.html).
 
@@ -565,6 +565,7 @@ Zero-shot, ~3 s reference prompt, scored by the benchmark's reference ASR and Wa
 | **dots.tts (MF, NFE=4)** | **2B** | 1.29 / 76.2 | 0.94 / 80.0 | 6.60 / 78.5 | 2.94 / 78.2 |
 | **dots.tts (MF-2steps)** | **2B** | 1.64 / 76.4 | 1.00 / 80.4 | 6.43 / 78.5 | 3.02 / 78.4 |
 | **dots.tts (MF-1step)** | **2B** | 1.59 / 76.6 | 1.02 / 80.2 | 6.63 / 78.1 | 3.08 / 78.3 |
+| **dots.tts (MF-2steps-STTS)** | **2B** | 1.41 / 75.3 | 1.04 / 79.2 | 7.83 / 76.9 | 3.43 / 77.1 |
 
 ### MiniMax Multilingual (24 languages)
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Notes:
 
 ### Checkpoints
 
-Six pretrained checkpoints are released on Hugging Face. They share the same backbone; choose by task and the quality / inference-cost tradeoff, then use the relevant CLI pattern above.
+Seven pretrained checkpoints are released on Hugging Face. They share the same backbone; choose by task and the quality / inference-cost tradeoff, then use the relevant CLI pattern above.
 
 | Model | Description | Checkpoint-specific settings |
 |---|---|---|
@@ -196,11 +196,14 @@ Six pretrained checkpoints are released on Hugging Face. They share the same bac
 | [`dots-studio/dots.tts-mf`](https://huggingface.co/dots-studio/dots.tts-mf) | MeanFlow-distilled student from `dots.tts-soar`. | NFE `4` is recommended. Fewer steps noticeably reduce quality; higher step counts are supported. CFG is fused into the student, so `--guidance-scale` has no effect. |
 | [`dots-studio/dots.tts-mf-2steps`](https://huggingface.co/dots-studio/dots.tts-mf-2steps) | Built on `dots.tts-mf` with a fixed two-step schedule for exact train–inference alignment and additional refinements. Uses the dedicated sCM solver at inference. | Omit sampling options; the artifact selects its fixed NFE `2` sCM contract. |
 | [`dots-studio/dots.tts-mf-1step`](https://huggingface.co/dots-studio/dots.tts-mf-1step) | Also built on `dots.tts-mf`, extending fixed-step training to one-step generation with further training refinements. | Omit sampling options; the artifact supplies its fixed NFE `1` contract. |
+| [`dots-studio/dots.tts-mf-2steps-stts`](https://huggingface.co/dots-studio/dots.tts-mf-2steps-stts) | Streaming-TTS checkpoint built for double-streaming use. It uses the same fixed two-step sCM sampling contract as MF-2steps. | Omit sampling options; the artifact selects its fixed NFE `2` sCM contract and streaming cadence. |
 | [`dots-studio/dots.tts.edit`](https://huggingface.co/dots-studio/dots.tts.edit) | Speech editing and zero-shot TTS checkpoint. | NFE `10`–`32` (default `10`); CFG defaults to `1.2`. |
 
 Pass the repo id directly to `--model-name-or-path` or `DotsTtsRuntime.from_pretrained`; the snapshot is fetched on first use and cached locally. Fixed-step artifacts reject incompatible sampling overrides.
 
 ### Python API
+
+#### Basic TTS
 
 ```python
 from dots_tts.runtime import DotsTtsRuntime
@@ -226,26 +229,6 @@ sf.write("output.wav", result["audio"].float().cpu().squeeze().numpy(), result["
 The fixed-step MeanFlow artifacts read their sampling contracts directly from
 the model configuration, so CLI and Python calls do not need sampling options.
 
-The same edit contract is available from Python:
-
-```python
-from dots_tts.edit_runtime import DotsTtsEditRuntime
-
-edit_runtime = DotsTtsEditRuntime.from_pretrained(
-    "dots-studio/dots.tts.edit",
-    precision="bfloat16",
-)
-result = edit_runtime.generate_edit(
-    source_audio_path="/path/to/source.wav",
-    instruction='Hello <sub targ="small">brave</sub> world.',
-    # source_text and target_text are optional overrides.
-    # use_xvector defaults to "auto"; pass True or False to override it.
-    num_steps=10,
-    guidance_scale=1.2,
-)
-sf.write("edited.wav", result["audio"].float().cpu().squeeze().numpy(), result["sample_rate"])
-```
-
 For low-latency playback or streaming to a client, use `generate_stream` instead — it yields audio chunks (`torch.Tensor`, shape `(1, samples)`) as they are produced. Arguments are identical to `generate`:
 
 ```python
@@ -266,6 +249,74 @@ for chunk in stream:
 
 audio = torch.cat(chunks, dim=-1).squeeze().numpy()
 sf.write("output_stream.wav", audio, runtime.sample_rate)
+```
+
+#### Double Streaming
+
+For duplex dialogue systems where an upstream LLM emits text tokens incrementally, use the double-streaming runtime. It accepts one text token at a time and returns either an audio chunk or `None` when the acoustic stream needs more text context.
+
+The recommended released checkpoint for this path is [`dots-studio/dots.tts-mf-2steps-stts`](https://huggingface.co/dots-studio/dots.tts-mf-2steps-stts). Its sampling and streaming settings are stored in the artifact, so callers only provide text and optional prompt audio/text.
+
+The same contract is available from Python:
+
+```python
+import torch
+import soundfile as sf
+
+from dots_tts.runtime_double_streaming import DotsTtsRuntimeDoubleStreaming
+
+runtime = DotsTtsRuntimeDoubleStreaming.from_pretrained(
+    "dots-studio/dots.tts-mf-2steps-stts",
+    precision="bfloat16",
+    optimize=True,
+    max_generate_length=500,
+)
+
+text = "你好呀，今天想聊点什么？或者有什么我能帮你的？"
+text_token_ids = runtime.model.tokenizer.encode(text, add_special_tokens=False)
+
+session = runtime.start_double_streaming(
+    prompt_audio_path="/path/to/reference.wav",
+    prompt_text="The exact transcript spoken in the reference audio.",
+)
+
+chunks = []
+for token_id in text_token_ids:
+    chunk = session.push_text_token(token_id)
+    if chunk is not None:
+        chunks.append(chunk.detach().cpu())
+
+for chunk in session.finish_text():
+    chunks.append(chunk.detach().cpu())
+
+audio = torch.cat(chunks, dim=-1).float().squeeze().numpy()
+sf.write("double_streaming.wav", audio, runtime.sample_rate)
+```
+
+`--optimize` is strongly recommended for double streaming. It adds a one-time `torch.compile` warmup at load time, but the steady-state path uses cached/compiled LLM, DiT, and vocoder steps and substantially reduces RTF and streaming gaps.
+
+For a complete command-line example, see [`scripts/example_double_streaming.py`](scripts/example_double_streaming.py).
+
+#### Speech Editing
+
+The same edit contract is available from Python:
+
+```python
+from dots_tts.edit_runtime import DotsTtsEditRuntime
+
+edit_runtime = DotsTtsEditRuntime.from_pretrained(
+    "dots-studio/dots.tts.edit",
+    precision="bfloat16",
+)
+result = edit_runtime.generate_edit(
+    source_audio_path="/path/to/source.wav",
+    instruction='Hello <sub targ="small">brave</sub> world.',
+    # source_text and target_text are optional overrides.
+    # use_xvector defaults to "auto"; pass True or False to override it.
+    num_steps=10,
+    guidance_scale=1.2,
+)
+sf.write("edited.wav", result["audio"].float().cpu().squeeze().numpy(), result["sample_rate"])
 ```
 
 ### Web Demo (Gradio)
@@ -484,7 +535,7 @@ A frozen **AudioVAE** encodes 48 kHz mono waveform into a continuous latent and 
 - **LLM** — initialized from **Qwen2.5-1.5B-Base**, consumes BPE text directly (no phonemes), and emits one hidden state per audio step.
 - **AR flow-matching head** — a DiT that conditions on the LLM hidden state and the AR prefix to denoise the next VAE patch, with a frozen CAM++ speaker x-vector as side input.
 
-Two sequence layouts: *plain mode* places the full text as a prefix before the audio span (standard TTS); *[1T1A interleaved mode](scripts/example_double_streaming.py)* alternates one BPE token with one audio step, enabling low-latency streaming when driven by a duplex dialogue LLM. See the technical report for full architectural and training details.
+Two sequence layouts: *plain mode* places the full text as a prefix before the audio span (standard TTS); *[double-streaming interleaved mode](scripts/example_double_streaming.py)* lets a caller push BPE text tokens incrementally while audio patches are decoded online using the checkpoint's declared streaming cadence. See the technical report for full architectural and training details.
 
 ---
 

--- a/scripts/example_double_streaming.py
+++ b/scripts/example_double_streaming.py
@@ -98,33 +98,6 @@ def parse_args(argv=None):
         help="Maximum number of decoded audio patches in double streaming",
     )
     parser.add_argument(
-        "--interleave-mode",
-        choices=("one_to_one", "buffered_ratio"),
-        default=None,
-        help=(
-            "Override online interleave mode. Defaults to the checkpoint training "
-            "config when available, otherwise one_to_one."
-        ),
-    )
-    parser.add_argument(
-        "--initial-lookahead",
-        type=int,
-        default=None,
-        help="Override buffered-ratio first audio text-token lookahead.",
-    )
-    parser.add_argument(
-        "--warmup-ta",
-        type=int,
-        default=None,
-        help="Override buffered-ratio warmup TA steps.",
-    )
-    parser.add_argument(
-        "--ta-per-tta",
-        type=int,
-        default=None,
-        help="Override buffered-ratio steady cycle TA count per TTA step.",
-    )
-    parser.add_argument(
         "--normalize-text",
         action="store_true",
         help="Normalize text before tokenizer encode",
@@ -181,10 +154,6 @@ def main(argv=None):
         num_steps=args.num_steps,
         guidance_scale=args.guidance_scale,
         eos_threshold=args.eos_threshold,
-        interleave_mode=args.interleave_mode,
-        initial_lookahead=args.initial_lookahead,
-        warmup_ta=args.warmup_ta,
-        ta_per_tta=args.ta_per_tta,
     )
     logger.info(
         "Double streaming session: template_name={} interleave_mode={} "

--- a/src/dots_tts/models/dots_tts/config.py
+++ b/src/dots_tts/models/dots_tts/config.py
@@ -95,6 +95,25 @@ class SamplingConfig(StrictConfigBase):
         return resolved
 
 
+class StreamingConfig(StrictConfigBase):
+    interleave_mode: Literal["one_to_one", "buffered_ratio"] = "one_to_one"
+    initial_lookahead: int | None = None
+    ta_per_tta: int = 2
+    warmup_ta: int = 1
+
+    @model_validator(mode="after")
+    def _validate_streaming_contract(self) -> "StreamingConfig":
+        if self.interleave_mode == "one_to_one":
+            return self
+        if self.initial_lookahead is not None and self.initial_lookahead <= 0:
+            raise ValueError("initial_lookahead must be positive.")
+        if self.ta_per_tta <= 0:
+            raise ValueError("ta_per_tta must be positive for buffered_ratio.")
+        if self.warmup_ta < 0:
+            raise ValueError("warmup_ta must be non-negative.")
+        return self
+
+
 class ModelConfig(ConfigBase):
     model_type: str = "dots_tts"
     latent_dim: int
@@ -109,6 +128,7 @@ class ModelConfig(ConfigBase):
     xvec_max_audio_seconds: float = 10.0
     meanflow: MeanFlowConfig | None = None
     sampling: SamplingConfig | None = None
+    streaming: StreamingConfig | None = None
 
 
 __all__ = [
@@ -116,4 +136,5 @@ __all__ = [
     "MeanFlowConfig",
     "ModelConfig",
     "SamplingConfig",
+    "StreamingConfig",
 ]

--- a/src/dots_tts/runtime_double_streaming.py
+++ b/src/dots_tts/runtime_double_streaming.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 import torch
-import yaml
 from loguru import logger
 
 from dots_tts.data.pipelines.tts_pipeline import TTS_INTERLEAVE_PREFIX
@@ -27,52 +25,7 @@ INTERLEAVE_MODE_BUFFERED_RATIO = "buffered_ratio"
 INTERLEAVE_MODES = frozenset(
     {INTERLEAVE_MODE_ONE_TO_ONE, INTERLEAVE_MODE_BUFFERED_RATIO}
 )
-DEFAULT_INTERLEAVE_PATTERN = (INTERLEAVE_MODE_ONE_TO_ONE, None, 2, 1)
-
-
-def _walk_mappings(value: Any):
-    if isinstance(value, dict):
-        yield value
-        for child in value.values():
-            yield from _walk_mappings(child)
-        return
-    if isinstance(value, list):
-        for child in value:
-            yield from _walk_mappings(child)
-
-
-def _load_interleave_pattern_from_training_config(
-    pretrained_path: Path,
-) -> tuple[str, int | None, int, int] | None:
-    for parent in (pretrained_path, *pretrained_path.parents):
-        config_path = parent / "config.yml"
-        if not config_path.is_file():
-            continue
-        try:
-            with config_path.open("r", encoding="utf-8") as fin:
-                config = yaml.safe_load(fin)
-        except Exception as exc:  # pragma: no cover - defensive config fallback
-            logger.warning(
-                logc(
-                    "stream",
-                    "Failed to read double streaming interleave config: path={} error={}",
-                ),
-                config_path,
-                exc,
-            )
-            return None
-        for mapping in _walk_mappings(config):
-            mode = mapping.get("interleave_mode")
-            if mode not in INTERLEAVE_MODES:
-                continue
-            return (
-                str(mode),
-                mapping.get("initial_lookahead"),
-                int(mapping.get("ta_per_tta", 2)),
-                int(mapping.get("warmup_ta", 1)),
-            )
-        return None
-    return None
+DEFAULT_INTERLEAVE_PATTERN = (INTERLEAVE_MODE_ONE_TO_ONE, 1, 0, 0)
 
 
 def normalize_interleave_pattern(
@@ -100,6 +53,20 @@ def normalize_interleave_pattern(
     if warmup_count < 0:
         raise ValueError("warmup_ta must be non-negative.")
     return interleave_mode, lookahead, ta_count, warmup_count
+
+
+def _load_interleave_pattern_from_model_config(
+    runtime: DotsTtsRuntime,
+) -> tuple[str, int | None, int, int]:
+    streaming = getattr(runtime.model.config, "streaming", None)
+    if streaming is None:
+        return DEFAULT_INTERLEAVE_PATTERN
+    return (
+        str(streaming.interleave_mode),
+        streaming.initial_lookahead,
+        int(streaming.ta_per_tta),
+        int(streaming.warmup_ta),
+    )
 
 
 def interleave_text_quota(
@@ -183,10 +150,6 @@ class DoubleStreamingSession:
         speaker_scale: float = 1.5,
         eos_threshold: float = 0.8,
         initial_silence_audio_tokens: int | None = None,
-        interleave_mode: str | None = None,
-        initial_lookahead: int | None = None,
-        ta_per_tta: int | None = None,
-        warmup_ta: int | None = None,
     ) -> None:
         normalized_prompt_text = runtime._process_prompt_text(prompt_text)
         if (
@@ -225,24 +188,17 @@ class DoubleStreamingSession:
         self.speaker_scale = float(speaker_scale)
         self.eos_threshold = float(eos_threshold)
         self.max_generate_length = runtime.max_generate_length
-        config_pattern = (
-            _load_interleave_pattern_from_training_config(runtime.pretrained_path)
-            or DEFAULT_INTERLEAVE_PATTERN
-        )
+        config_pattern = _load_interleave_pattern_from_model_config(runtime)
         (
             self.interleave_mode,
             self.initial_lookahead,
             self.ta_per_tta,
             self.warmup_ta,
         ) = normalize_interleave_pattern(
-            interleave_mode=interleave_mode or config_pattern[0],
-            initial_lookahead=(
-                initial_lookahead
-                if initial_lookahead is not None
-                else config_pattern[1]
-            ),
-            ta_per_tta=ta_per_tta if ta_per_tta is not None else config_pattern[2],
-            warmup_ta=warmup_ta if warmup_ta is not None else config_pattern[3],
+            interleave_mode=config_pattern[0],
+            initial_lookahead=config_pattern[1],
+            ta_per_tta=config_pattern[2],
+            warmup_ta=config_pattern[3],
         )
         if initial_silence_audio_tokens is None:
             initial_silence_audio_tokens = (
@@ -730,10 +686,6 @@ class DotsTtsRuntimeDoubleStreaming(DotsTtsRuntime):
         speaker_scale: float = 1.5,
         eos_threshold: float = 0.8,
         initial_silence_audio_tokens: int | None = None,
-        interleave_mode: str | None = None,
-        initial_lookahead: int | None = None,
-        ta_per_tta: int | None = None,
-        warmup_ta: int | None = None,
     ) -> DoubleStreamingSession:
         return DoubleStreamingSession(
             self,
@@ -746,10 +698,6 @@ class DotsTtsRuntimeDoubleStreaming(DotsTtsRuntime):
             speaker_scale=speaker_scale,
             eos_threshold=eos_threshold,
             initial_silence_audio_tokens=initial_silence_audio_tokens,
-            interleave_mode=interleave_mode,
-            initial_lookahead=initial_lookahead,
-            ta_per_tta=ta_per_tta,
-            warmup_ta=warmup_ta,
         )
 
 


### PR DESCRIPTION
## Summary

- add `StreamingConfig` support to model config and read double-streaming cadence from `config.json`
- make double-streaming inference fall back to `one_to_one` when no streaming config is provided
- remove explicit interleave cadence overrides from the public double-streaming API and example script
- document the released `dots-studio/dots.tts-mf-2steps-stts` double-streaming workflow in the README

## Notes

The `dots-studio/dots.tts-mf-2steps-stts` artifact now declares its streaming cadence in `config.json`, so callers do not need to pass `interleave_mode`, `initial_lookahead`, `warmup_ta`, or `ta_per_tta`.

## Testing

- `git diff --check -- README.md scripts/example_double_streaming.py src/dots_tts/models/dots_tts/config.py src/dots_tts/runtime_double_streaming.py`
- `ruff check src/dots_tts/models/dots_tts/config.py src/dots_tts/runtime_double_streaming.py scripts/example_double_streaming.py`
- `python -m py_compile src/dots_tts/models/dots_tts/config.py src/dots_tts/runtime_double_streaming.py scripts/example_double_streaming.py`
- `python scripts/example_double_streaming.py --help`
