### PR TITLE
Fix MeanFlow compiled prefill cache shape

### DIFF
--- a/src/dots_tts/models/dots_tts/model.py
+++ b/src/dots_tts/models/dots_tts/model.py
@@ -1222,10 +1222,13 @@ class DotsTtsModel(nn.Module):
             cfg_sequence = state.fm_cfg_sequence
             if solver_mode == "flow_matching" and cfg_sequence is None:
                 raise RuntimeError("FM cfg static buffer is not initialized.")
+            solver_cfg_sequence = (
+                cfg_sequence if solver_mode == "flow_matching" else None
+            )
             audio_patch = self._get_dit_solver(solver_mode=solver_mode).decode_next(
                 state.fm_dit_state,
                 sequence=sequence,
-                cfg_sequence=None if solver_mode == "scm" else cfg_sequence,
+                cfg_sequence=solver_cfg_sequence,
                 fm_seq_len=state.fm_seq_len,
                 null_g_cond=null_g_cond,
                 g_cond=g_cond,

--- a/src/dots_tts/modules/backbone/dit_inference.py
+++ b/src/dots_tts/modules/backbone/dit_inference.py
@@ -1521,7 +1521,10 @@ class DiTSolver:
             raise RuntimeError(
                 "Cannot decode audio before any conditioning state has been prefetched."
             )
-        if not self.meanflow:
+        if self.meanflow:
+            if cfg_sequence is not None:
+                raise ValueError("MeanFlow DiTSolver does not accept cfg_sequence.")
+        else:
             if cfg_sequence is None:
                 raise ValueError("FlowMatching DiTSolver requires cfg_sequence.")
             if guidance_scale is None:


### PR DESCRIPTION
## Summary
- avoid passing CFG prefill sequences into MeanFlow DiT decode
- defensively clear cfg_sequence inside the optimized MeanFlow solver path
- fixes the dots.tts==0.3.0 optimize warmup shape mismatch where a single-branch MeanFlow cache receives two-branch CFG prefill K/V tensors

## Verification
- python -m compileall -q src/dots_tts/models/dots_tts/model.py src/dots_tts/modules/backbone/dit_inference.py
- DOTS_TTS_DELAYED_DIT_BACKEND=sdpa PYTHONPATH=src python - <<'PY'
from dots_tts.runtime import DotsTtsRuntime
rt = DotsTtsRuntime.from_pretrained('pretrained_ckpts/mf_d4base_step22000/checkpoint-00022000/model', precision='bfloat16', optimize=True, max_generate_length=64, warmup_on_optimize=False)
rt._run_warmup_iteration(prompt_patch_count=30, target_patch_count=1)
PY
- DOTS_TTS_DELAYED_DIT_BACKEND=flex PYTHONPATH=src python - <<'PY'
from dots_tts.runtime import DotsTtsRuntime
rt = DotsTtsRuntime.from_pretrained('pretrained_ckpts/mf_d4base_step22000/checkpoint-00022000/model', precision='bfloat16', optimize=True, max_generate_length=64, warmup_on_optimize=False)
rt._run_warmup_iteration(prompt_patch_count=30, target_patch_count=1)
PY

## Release note
PyPI users installing dots.tts==0.3.0 will still receive the affected package; this fix needs a patch release such as 0.3.1 to be available through normal pip installs.