### PR TITLE
Fix silent CPU fallback on Apple Silicon (MPS)

### DIFF
--- a/src/dots_tts/runtime.py
+++ b/src/dots_tts/runtime.py
@@ -61,7 +61,7 @@ class DotsTtsRuntime:
     def _check_torch_env(precision: str) -> None:
         import warnings
 
-        if torch.cuda.is_available():
+        if torch.cuda.is_available() or torch.backends.mps.is_available():
             return
         msg = (
             f"CUDA is not available; torch will run on CPU. "
@@ -94,6 +94,8 @@ class DotsTtsRuntime:
         self.precision = precision
         if torch.cuda.is_available():
             self.device = torch.device("cuda")
+        elif torch.backends.mps.is_available():
+            self.device = torch.device("mps")
         else:
             self.device = torch.device("cpu")
             torch.set_num_threads(1)


### PR DESCRIPTION
`DotsTtsRuntime._check_torch_env` and `__init__` only check `torch.cuda.is_available()`, so on Apple Silicon the runtime silently falls back to CPU — including the `torch.set_num_threads(1)` clamp — even when MPS is available. CPU-only inference is ~8x slower than MPS for this model.

This adds an explicit MPS branch in both places, so Mac users get GPU acceleration by default instead of a silent, much slower fallback.

Related to #25 (extremely slow generation reported on an M1 Pro) — silent CPU fallback would produce exactly that symptom, though I can't confirm it's the sole cause of that report.

Tested in production on Apple Silicon (torch/MPS) for several weeks.